### PR TITLE
Specify string format when printing recommender name

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -100,7 +100,7 @@ const (
 func main() {
 	klog.InitFlags(nil)
 	kube_flag.InitFlags()
-	klog.V(1).Infof("Vertical Pod Autoscaler %s Recommender: %v", common.VerticalPodAutoscalerVersion, *recommenderName)
+	klog.V(1).Infof("Vertical Pod Autoscaler %s Recommender: %s", common.VerticalPodAutoscalerVersion, *recommenderName)
 
 	config := common.CreateKubeConfigOrDie(*kubeconfig, float32(*kubeApiQps), int(*kubeApiBurst))
 	kubeClient := kube_client.NewForConfigOrDie(config)


### PR DESCRIPTION
Testing out the dev loop by replacing `%v` format verb with `%s` for the string recommender name.

Deployed to `dev-aws-ca-central-1`
<img width="1351" alt="Screenshot 2024-04-02 at 10 53 07 AM" src="https://github.com/jodzga/autoscaler/assets/52840591/3953211b-4c6d-4571-80f7-d851a7744b90">
