### PR TITLE
Naive implementation of RSS recommendation in VPA objects

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client.go
@@ -111,8 +111,12 @@ func calculateUsage(containerUsage k8sapiv1.ResourceList) model.Resources {
 	memoryQuantity := containerUsage[k8sapiv1.ResourceMemory]
 	memoryBytes := memoryQuantity.Value()
 
+	rssQuantity := containerUsage[k8sapiv1.ResourceName(model.ResourceRSS)]
+	rssBytes := rssQuantity.Value()
+
 	return model.Resources{
 		model.ResourceCPU:    model.ResourceAmount(cpuMillicores),
 		model.ResourceMemory: model.ResourceAmount(memoryBytes),
+		model.ResourceRSS:    model.ResourceAmount(rssBytes),
 	}
 }

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client_test_util.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client_test_util.go
@@ -76,6 +76,7 @@ func (tc *metricsClientTestCase) newContainerMetricsSnapshot(id model.ContainerI
 		Usage: model.Resources{
 			model.ResourceCPU:    model.ResourceAmount(cpuUsage),
 			model.ResourceMemory: model.ResourceAmount(memUsage),
+			model.ResourceRSS:    0,
 		},
 	}
 }
@@ -126,9 +127,13 @@ func calculateResourceList(usage model.Resources) k8sapiv1.ResourceList {
 	memoryBytes := big.NewInt(int64(usage[model.ResourceMemory]))
 	memoryQuantityString := memoryBytes.String()
 
+	rssBytes := big.NewInt(int64(usage[model.ResourceRSS]))
+	rssQuantityString := rssBytes.String()
+
 	resourceMap := map[k8sapiv1.ResourceName]resource.Quantity{
-		k8sapiv1.ResourceCPU:    resource.MustParse(cpuQuantityString),
-		k8sapiv1.ResourceMemory: resource.MustParse(memoryQuantityString),
+		k8sapiv1.ResourceCPU:                     resource.MustParse(cpuQuantityString),
+		k8sapiv1.ResourceMemory:                  resource.MustParse(memoryQuantityString),
+		k8sapiv1.ResourceName(model.ResourceRSS): resource.MustParse(rssQuantityString),
 	}
 	return k8sapiv1.ResourceList(resourceMap)
 }

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client_test_util.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client_test_util.go
@@ -85,7 +85,7 @@ func (tc *metricsClientTestCase) createFakeMetricsClient() MetricsClient {
 	fakeMetricsGetter.AddReactor("list", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
 		return true, tc.getFakePodMetricsList(), nil
 	})
-	return NewMetricsClient(NewPodMetricsesSource(fakeMetricsGetter.MetricsV1beta1()), "", "fake")
+	return NewMetricsClient(NewPodMetricsesSource(fakeMetricsGetter.MetricsV1beta1(), ""), "", "fake")
 }
 
 func (tc *metricsClientTestCase) getFakePodMetricsList() *metricsapi.PodMetricsList {

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
@@ -159,6 +159,11 @@ func (s podMetricsSource) List(ctx context.Context, namespace string, opts v1.Li
 		return nil, err
 	}
 
+	if s.m3Url == "" {
+		klog.Info("No M3 URL provided - skipping custom pod usage metrics")
+		return podsMetrics, nil
+	}
+
 	return s.withM3CustomMetrics(podsMetrics)
 }
 

--- a/vertical-pod-autoscaler/pkg/recommender/logic/estimator.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/estimator.go
@@ -100,6 +100,8 @@ func (e *percentileEstimator) GetResourceEstimation(s *model.AggregateContainerS
 			s.AggregateCPUUsage.Percentile(e.cpuPercentile)),
 		model.ResourceMemory: model.MemoryAmountFromBytes(
 			s.AggregateMemoryPeaks.Percentile(e.memoryPercentile)),
+		// TODO: Take percentile once RSS aggregation moves away from the naive max to by histogram.
+		model.ResourceRSS: model.MemoryAmountFromBytes(s.RSSBytes),
 	}
 }
 

--- a/vertical-pod-autoscaler/pkg/recommender/logic/recommender.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/recommender.go
@@ -28,6 +28,7 @@ var (
 	safetyMarginFraction = flag.Float64("recommendation-margin-fraction", 0.15, `Fraction of usage added as the safety margin to the recommended request`)
 	podMinCPUMillicores  = flag.Float64("pod-recommendation-min-cpu-millicores", 25, `Minimum CPU recommendation for a pod`)
 	podMinMemoryMb       = flag.Float64("pod-recommendation-min-memory-mb", 250, `Minimum memory recommendation for a pod`)
+	podMinRSSMb          = flag.Float64("pod-recommendation-min-rss-mb", 0, `Minimum RSS recommendation for a pod`)
 	targetCPUPercentile  = flag.Float64("target-cpu-percentile", 0.9, "CPU usage percentile that will be used as a base for CPU target recommendation. Doesn't affect CPU lower bound, CPU upper bound nor memory recommendations.")
 )
 
@@ -66,6 +67,7 @@ func (r *podResourceRecommender) GetRecommendedPodResources(containerNameToAggre
 	minResources := model.Resources{
 		model.ResourceCPU:    model.ScaleResource(model.CPUAmountFromCores(*podMinCPUMillicores*0.001), fraction),
 		model.ResourceMemory: model.ScaleResource(model.MemoryAmountFromBytes(*podMinMemoryMb*1024*1024), fraction),
+		model.ResourceRSS:    model.ScaleResource(model.MemoryAmountFromBytes(*podMinRSSMb*1024*1024), fraction),
 	}
 
 	recommender := &podResourceRecommender{

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -146,7 +146,7 @@ func main() {
 		source = input_metrics.NewExternalClient(config, clusterState, *externalClientOptions)
 	} else {
 		klog.V(1).Infof("Using Metrics Server.")
-		source = input_metrics.NewPodMetricsesSource(resourceclient.NewForConfigOrDie(config))
+		source = input_metrics.NewPodMetricsesSource(resourceclient.NewForConfigOrDie(config), *prometheusAddress)
 	}
 
 	clusterStateFeeder := input.ClusterStateFeederFactory{

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
@@ -59,8 +59,8 @@ const (
 )
 
 var (
-	// TODO: Remove ResourceRSS from default (requires updating all our VPAs to include ResourceRSS in container policies).
 	// DefaultControlledResources is a default value of Spec.ResourcePolicy.ContainerPolicies[].ControlledResources.
+	// TODO: Remove ResourceRSS from default (requires updating all our VPAs to include ResourceRSS in container policies).
 	DefaultControlledResources = []ResourceName{ResourceCPU, ResourceMemory, ResourceRSS}
 )
 

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
@@ -60,7 +60,7 @@ const (
 
 var (
 	// DefaultControlledResources is a default value of Spec.ResourcePolicy.ContainerPolicies[].ControlledResources.
-	DefaultControlledResources = []ResourceName{ResourceCPU, ResourceMemory}
+	DefaultControlledResources = []ResourceName{ResourceCPU, ResourceMemory, ResourceRSS}
 )
 
 // ContainerStateAggregator is an interface for objects that consume and
@@ -94,6 +94,9 @@ type AggregateContainerState struct {
 	// AggregateMemoryPeaks is a distribution of memory peaks from all containers:
 	// each container should add one peak per memory aggregation interval (e.g. once every 24h).
 	AggregateMemoryPeaks util.Histogram
+	// RSSBytes is the max 5m-average RSS observed of all RSS samples (naive implementation).
+	// TODO: aggregate properly with histogram once VPACheckpoint updated to support additional histogram.
+	RSSBytes float64
 	// Note: first/last sample timestamps as well as the sample count are based only on CPU samples.
 	FirstSampleStart  time.Time
 	LastSampleStart   time.Time
@@ -157,6 +160,7 @@ func (a *AggregateContainerState) MarkNotAutoscaled() {
 func (a *AggregateContainerState) MergeContainerState(other *AggregateContainerState) {
 	a.AggregateCPUUsage.Merge(other.AggregateCPUUsage)
 	a.AggregateMemoryPeaks.Merge(other.AggregateMemoryPeaks)
+	a.RSSBytes = math.Max(a.RSSBytes, other.RSSBytes)
 
 	if a.FirstSampleStart.IsZero() ||
 		(!other.FirstSampleStart.IsZero() && other.FirstSampleStart.Before(a.FirstSampleStart)) {
@@ -174,6 +178,7 @@ func NewAggregateContainerState() *AggregateContainerState {
 	return &AggregateContainerState{
 		AggregateCPUUsage:    util.NewDecayingHistogram(config.CPUHistogramOptions, config.CPUHistogramDecayHalfLife),
 		AggregateMemoryPeaks: util.NewDecayingHistogram(config.MemoryHistogramOptions, config.MemoryHistogramDecayHalfLife),
+		RSSBytes:             0,
 		CreationTime:         time.Now(),
 	}
 }
@@ -185,6 +190,8 @@ func (a *AggregateContainerState) AddSample(sample *ContainerUsageSample) {
 		a.addCPUSample(sample)
 	case ResourceMemory:
 		a.AggregateMemoryPeaks.AddSample(BytesFromMemoryAmount(sample.Usage), 1.0, sample.MeasureStart)
+	case ResourceRSS:
+		a.addRSSSample(sample)
 	default:
 		panic(fmt.Sprintf("AddSample doesn't support resource '%s'", sample.Resource))
 	}
@@ -212,6 +219,19 @@ func (a *AggregateContainerState) addCPUSample(sample *ContainerUsageSample) {
 	// which helps react quickly to CPU starvation.
 	a.AggregateCPUUsage.AddSample(
 		cpuUsageCores, math.Max(cpuRequestCores, minSampleWeight), sample.MeasureStart)
+	if sample.MeasureStart.After(a.LastSampleStart) {
+		a.LastSampleStart = sample.MeasureStart
+	}
+	if a.FirstSampleStart.IsZero() || sample.MeasureStart.Before(a.FirstSampleStart) {
+		a.FirstSampleStart = sample.MeasureStart
+	}
+	a.TotalSamplesCount++
+}
+
+func (a *AggregateContainerState) addRSSSample(sample *ContainerUsageSample) {
+	// RSSBytes is the max 5m-average RSS observed of all RSS samples (naive implementation).
+	// TODO: aggregate properly with histogram once VPACheckpoint updated to support additional histogram.
+	a.RSSBytes = math.Max(a.RSSBytes, BytesFromMemoryAmount(sample.Usage))
 	if sample.MeasureStart.After(a.LastSampleStart) {
 		a.LastSampleStart = sample.MeasureStart
 	}

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
@@ -59,6 +59,7 @@ const (
 )
 
 var (
+	// TODO: Remove ResourceRSS from default (requires updating all our VPAs to include ResourceRSS in container policies).
 	// DefaultControlledResources is a default value of Spec.ResourcePolicy.ContainerPolicies[].ControlledResources.
 	DefaultControlledResources = []ResourceName{ResourceCPU, ResourceMemory, ResourceRSS}
 )
@@ -95,7 +96,7 @@ type AggregateContainerState struct {
 	// each container should add one peak per memory aggregation interval (e.g. once every 24h).
 	AggregateMemoryPeaks util.Histogram
 	// RSSBytes is the max 5m-average RSS observed of all RSS samples (naive implementation).
-	// TODO: aggregate properly with histogram once VPACheckpoint updated to support additional histogram.
+	// TODO: Aggregate properly with histogram once VPACheckpoint updated to support additional histogram.
 	RSSBytes float64
 	// Note: first/last sample timestamps as well as the sample count are based only on CPU samples.
 	FirstSampleStart  time.Time
@@ -230,7 +231,7 @@ func (a *AggregateContainerState) addCPUSample(sample *ContainerUsageSample) {
 
 func (a *AggregateContainerState) addRSSSample(sample *ContainerUsageSample) {
 	// RSSBytes is the max 5m-average RSS observed of all RSS samples (naive implementation).
-	// TODO: aggregate properly with histogram once VPACheckpoint updated to support additional histogram.
+	// TODO: Aggregate properly with histogram once VPACheckpoint updated to support additional histogram.
 	a.RSSBytes = math.Max(a.RSSBytes, BytesFromMemoryAmount(sample.Usage))
 	if sample.MeasureStart.After(a.LastSampleStart) {
 		a.LastSampleStart = sample.MeasureStart

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state_test.go
@@ -279,11 +279,11 @@ func TestUpdateFromPolicyControlledResources(t *testing.T) {
 		}, {
 			name:     "No ControlledResources specified - used default",
 			policy:   &vpa_types.ContainerResourcePolicy{},
-			expected: []ResourceName{ResourceCPU, ResourceMemory},
+			expected: []ResourceName{ResourceCPU, ResourceMemory, ResourceRSS},
 		}, {
 			name:     "Nil policy - use default",
 			policy:   nil,
-			expected: []ResourceName{ResourceCPU, ResourceMemory},
+			expected: []ResourceName{ResourceCPU, ResourceMemory, ResourceRSS},
 		},
 	}
 	for _, tc := range testCases {

--- a/vertical-pod-autoscaler/pkg/recommender/model/types.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/types.go
@@ -39,6 +39,8 @@ const (
 	ResourceCPU ResourceName = "cpu"
 	// ResourceMemory represents memory, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024).
 	ResourceMemory ResourceName = "memory"
+	// ResourceRSS represents RSS, in bytes.
+	ResourceRSS ResourceName = "rss"
 	// MaxResourceAmount is the maximum allowed value of resource amount.
 	MaxResourceAmount = ResourceAmount(1e14)
 )
@@ -91,6 +93,9 @@ func ResourcesAsResourceList(resources Resources) apiv1.ResourceList {
 		case ResourceMemory:
 			newKey = apiv1.ResourceMemory
 			quantity = QuantityFromMemoryAmount(resourceAmount)
+		case ResourceRSS:
+			newKey = apiv1.ResourceName(ResourceRSS)
+			quantity = QuantityFromMemoryAmount(resourceAmount)
 		default:
 			klog.Errorf("Cannot translate %v resource name", key)
 			continue
@@ -109,6 +114,8 @@ func ResourceNamesApiToModel(resources []apiv1.ResourceName) *[]ResourceName {
 			result = append(result, ResourceCPU)
 		case apiv1.ResourceMemory:
 			result = append(result, ResourceMemory)
+		case apiv1.ResourceName(ResourceRSS):
+			result = append(result, ResourceRSS)
 		default:
 			klog.Errorf("Cannot translate %v resource name", resource)
 			continue


### PR DESCRIPTION
Adds RSS recommendations to VPA objects. Note that this is a naive implementation where for a container the max 5m-average RSS value (over all samples) is used as the recommendation. Queries M3 for these values.

This is to be converted into a histogram once VPA Checkpoints are updated to support an additional histogram.