### PR TITLE
Naive implementation of JVM Heap recs in VPA objects

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client.go
@@ -114,9 +114,13 @@ func calculateUsage(containerUsage k8sapiv1.ResourceList) model.Resources {
 	rssQuantity := containerUsage[k8sapiv1.ResourceName(model.ResourceRSS)]
 	rssBytes := rssQuantity.Value()
 
+	jvmHeapQuantity := containerUsage[k8sapiv1.ResourceName(model.ResourceJVMHeap)]
+	jvmHeapBytes := jvmHeapQuantity.Value()
+
 	return model.Resources{
-		model.ResourceCPU:    model.ResourceAmount(cpuMillicores),
-		model.ResourceMemory: model.ResourceAmount(memoryBytes),
-		model.ResourceRSS:    model.ResourceAmount(rssBytes),
+		model.ResourceCPU:     model.ResourceAmount(cpuMillicores),
+		model.ResourceMemory:  model.ResourceAmount(memoryBytes),
+		model.ResourceRSS:     model.ResourceAmount(rssBytes),
+		model.ResourceJVMHeap: model.ResourceAmount(jvmHeapBytes),
 	}
 }

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client_test_util.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client_test_util.go
@@ -74,9 +74,10 @@ func (tc *metricsClientTestCase) newContainerMetricsSnapshot(id model.ContainerI
 		SnapshotTime:   tc.snapshotTimestamp,
 		SnapshotWindow: tc.snapshotWindow,
 		Usage: model.Resources{
-			model.ResourceCPU:    model.ResourceAmount(cpuUsage),
-			model.ResourceMemory: model.ResourceAmount(memUsage),
-			model.ResourceRSS:    0,
+			model.ResourceCPU:     model.ResourceAmount(cpuUsage),
+			model.ResourceMemory:  model.ResourceAmount(memUsage),
+			model.ResourceRSS:     0,
+			model.ResourceJVMHeap: 0,
 		},
 	}
 }
@@ -130,10 +131,14 @@ func calculateResourceList(usage model.Resources) k8sapiv1.ResourceList {
 	rssBytes := big.NewInt(int64(usage[model.ResourceRSS]))
 	rssQuantityString := rssBytes.String()
 
+	jvmHeapBytes := big.NewInt(int64(usage[model.ResourceJVMHeap]))
+	jvmHeapQuantityString := jvmHeapBytes.String()
+
 	resourceMap := map[k8sapiv1.ResourceName]resource.Quantity{
-		k8sapiv1.ResourceCPU:                     resource.MustParse(cpuQuantityString),
-		k8sapiv1.ResourceMemory:                  resource.MustParse(memoryQuantityString),
-		k8sapiv1.ResourceName(model.ResourceRSS): resource.MustParse(rssQuantityString),
+		k8sapiv1.ResourceCPU:                         resource.MustParse(cpuQuantityString),
+		k8sapiv1.ResourceMemory:                      resource.MustParse(memoryQuantityString),
+		k8sapiv1.ResourceName(model.ResourceRSS):     resource.MustParse(rssQuantityString),
+		k8sapiv1.ResourceName(model.ResourceJVMHeap): resource.MustParse(jvmHeapQuantityString),
 	}
 	return k8sapiv1.ResourceList(resourceMap)
 }

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
@@ -61,6 +61,10 @@ func getRSSQuery(containerName string, podName string, namespace string) string 
 	return fmt.Sprintf("max_over_time(container_memory_rss{container_name='%s', pod_name='%s', namespace='%s'}[5m])", containerName, podName, namespace)
 }
 
+func getJVMHeapQuery(containerName string, podName string, namespace string) string {
+	return fmt.Sprintf("max_over_time(jmx_Memory_HeapMemoryUsage_committed{kubernetes_container_name='%s', kubernetes_pod_name='%s', kubernetes_namespace='%s'}[5m])", containerName, podName, namespace)
+}
+
 // Augments the PodMetricsList with custom metrics from M3.
 func (s podMetricsSource) withM3CustomMetrics(podMetrics *v1beta1.PodMetricsList) (*v1beta1.PodMetricsList, error) {
 	m3Url, err := url.Parse(s.m3Url)
@@ -73,7 +77,8 @@ func (s podMetricsSource) withM3CustomMetrics(podMetrics *v1beta1.PodMetricsList
 	for i, pod := range podMetrics.Items {
 		for j, container := range pod.Containers {
 			queries := map[string]k8sapiv1.ResourceName{
-				getRSSQuery(container.Name, pod.Name, pod.Namespace): k8sapiv1.ResourceName(model.ResourceRSS),
+				getRSSQuery(container.Name, pod.Name, pod.Namespace):     k8sapiv1.ResourceName(model.ResourceRSS),
+				getJVMHeapQuery(container.Name, pod.Name, pod.Namespace): k8sapiv1.ResourceName(model.ResourceJVMHeap),
 			}
 			for query, resourceName := range queries {
 				params := url.Values{}

--- a/vertical-pod-autoscaler/pkg/recommender/logic/estimator.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/estimator.go
@@ -100,8 +100,9 @@ func (e *percentileEstimator) GetResourceEstimation(s *model.AggregateContainerS
 			s.AggregateCPUUsage.Percentile(e.cpuPercentile)),
 		model.ResourceMemory: model.MemoryAmountFromBytes(
 			s.AggregateMemoryPeaks.Percentile(e.memoryPercentile)),
-		// TODO: Take percentile once RSS aggregation moves away from the naive max to by histogram.
-		model.ResourceRSS: model.MemoryAmountFromBytes(s.RSSBytes),
+		// TODO: Take percentile once RSS + JVM Heap aggregation moves away from the naive max to by histogram.
+		model.ResourceRSS:     model.MemoryAmountFromBytes(s.RSSBytes),
+		model.ResourceJVMHeap: model.MemoryAmountFromBytes(s.JVMHeapBytes),
 	}
 }
 

--- a/vertical-pod-autoscaler/pkg/recommender/logic/recommender.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/recommender.go
@@ -29,6 +29,7 @@ var (
 	podMinCPUMillicores  = flag.Float64("pod-recommendation-min-cpu-millicores", 25, `Minimum CPU recommendation for a pod`)
 	podMinMemoryMb       = flag.Float64("pod-recommendation-min-memory-mb", 250, `Minimum memory recommendation for a pod`)
 	podMinRSSMb          = flag.Float64("pod-recommendation-min-rss-mb", 0, `Minimum RSS recommendation for a pod`)
+	podMinJVMHeapMb      = flag.Float64("pod-recommendation-min-jvmheap-mb", 0, `Minimum JVM Heap recommendation for a pod`)
 	targetCPUPercentile  = flag.Float64("target-cpu-percentile", 0.9, "CPU usage percentile that will be used as a base for CPU target recommendation. Doesn't affect CPU lower bound, CPU upper bound nor memory recommendations.")
 )
 
@@ -65,9 +66,10 @@ func (r *podResourceRecommender) GetRecommendedPodResources(containerNameToAggre
 
 	fraction := 1.0 / float64(len(containerNameToAggregateStateMap))
 	minResources := model.Resources{
-		model.ResourceCPU:    model.ScaleResource(model.CPUAmountFromCores(*podMinCPUMillicores*0.001), fraction),
-		model.ResourceMemory: model.ScaleResource(model.MemoryAmountFromBytes(*podMinMemoryMb*1024*1024), fraction),
-		model.ResourceRSS:    model.ScaleResource(model.MemoryAmountFromBytes(*podMinRSSMb*1024*1024), fraction),
+		model.ResourceCPU:     model.ScaleResource(model.CPUAmountFromCores(*podMinCPUMillicores*0.001), fraction),
+		model.ResourceMemory:  model.ScaleResource(model.MemoryAmountFromBytes(*podMinMemoryMb*1024*1024), fraction),
+		model.ResourceRSS:     model.ScaleResource(model.MemoryAmountFromBytes(*podMinRSSMb*1024*1024), fraction),
+		model.ResourceJVMHeap: model.ScaleResource(model.MemoryAmountFromBytes(*podMinJVMHeapMb*1024*1024), fraction),
 	}
 
 	recommender := &podResourceRecommender{

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state_test.go
@@ -279,11 +279,11 @@ func TestUpdateFromPolicyControlledResources(t *testing.T) {
 		}, {
 			name:     "No ControlledResources specified - used default",
 			policy:   &vpa_types.ContainerResourcePolicy{},
-			expected: []ResourceName{ResourceCPU, ResourceMemory, ResourceRSS},
+			expected: []ResourceName{ResourceCPU, ResourceMemory, ResourceRSS, ResourceJVMHeap},
 		}, {
 			name:     "Nil policy - use default",
 			policy:   nil,
-			expected: []ResourceName{ResourceCPU, ResourceMemory, ResourceRSS},
+			expected: []ResourceName{ResourceCPU, ResourceMemory, ResourceRSS, ResourceJVMHeap},
 		},
 	}
 	for _, tc := range testCases {

--- a/vertical-pod-autoscaler/pkg/recommender/model/types.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/types.go
@@ -41,6 +41,8 @@ const (
 	ResourceMemory ResourceName = "memory"
 	// ResourceRSS represents RSS, in bytes.
 	ResourceRSS ResourceName = "rss"
+	// ResourceJVMHeap represents committed JVM Heap, in bytes.
+	ResourceJVMHeap ResourceName = "jvmheap"
 	// MaxResourceAmount is the maximum allowed value of resource amount.
 	MaxResourceAmount = ResourceAmount(1e14)
 )
@@ -96,6 +98,9 @@ func ResourcesAsResourceList(resources Resources) apiv1.ResourceList {
 		case ResourceRSS:
 			newKey = apiv1.ResourceName(ResourceRSS)
 			quantity = QuantityFromMemoryAmount(resourceAmount)
+		case ResourceJVMHeap:
+			newKey = apiv1.ResourceName(ResourceJVMHeap)
+			quantity = QuantityFromMemoryAmount(resourceAmount)
 		default:
 			klog.Errorf("Cannot translate %v resource name", key)
 			continue
@@ -116,6 +121,8 @@ func ResourceNamesApiToModel(resources []apiv1.ResourceName) *[]ResourceName {
 			result = append(result, ResourceMemory)
 		case apiv1.ResourceName(ResourceRSS):
 			result = append(result, ResourceRSS)
+		case apiv1.ResourceName(ResourceJVMHeap):
+			result = append(result, ResourceJVMHeap)
 		default:
 			klog.Errorf("Cannot translate %v resource name", resource)
 			continue

--- a/vertical-pod-autoscaler/pkg/recommender/model/types.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/types.go
@@ -42,7 +42,7 @@ const (
 	// ResourceRSS represents RSS, in bytes.
 	ResourceRSS ResourceName = "rss"
 	// ResourceJVMHeap represents committed JVM Heap, in bytes.
-	ResourceJVMHeap ResourceName = "jvmHeap"
+	ResourceJVMHeap ResourceName = "jvmHeapCommitted"
 	// MaxResourceAmount is the maximum allowed value of resource amount.
 	MaxResourceAmount = ResourceAmount(1e14)
 )

--- a/vertical-pod-autoscaler/pkg/recommender/model/types.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/types.go
@@ -42,7 +42,7 @@ const (
 	// ResourceRSS represents RSS, in bytes.
 	ResourceRSS ResourceName = "rss"
 	// ResourceJVMHeap represents committed JVM Heap, in bytes.
-	ResourceJVMHeap ResourceName = "jvmheap"
+	ResourceJVMHeap ResourceName = "jvmHeap"
 	// MaxResourceAmount is the maximum allowed value of resource amount.
 	MaxResourceAmount = ResourceAmount(1e14)
 )


### PR DESCRIPTION
Adds JVM Heap recommendations to VPA objects. Note that this is a naive implementation where for a container the max 5m-average committed JVM heap value (over all samples) is used as the recommendation. Queries M3 for these values.

This is to be converted into a histogram once VPA Checkpoints are updated to support an additional histogram.