### PR TITLE
Set min WSS memory recommendation as 0

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/logic/recommender.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/recommender.go
@@ -27,7 +27,7 @@ import (
 var (
 	safetyMarginFraction = flag.Float64("recommendation-margin-fraction", 0.15, `Fraction of usage added as the safety margin to the recommended request`)
 	podMinCPUMillicores  = flag.Float64("pod-recommendation-min-cpu-millicores", 25, `Minimum CPU recommendation for a pod`)
-	podMinMemoryMb       = flag.Float64("pod-recommendation-min-memory-mb", 250, `Minimum memory recommendation for a pod`)
+	podMinMemoryMb       = flag.Float64("pod-recommendation-min-memory-mb", 0, `Minimum memory recommendation for a pod`)
 	podMinRSSMb          = flag.Float64("pod-recommendation-min-rss-mb", 0, `Minimum RSS recommendation for a pod`)
 	podMinJVMHeapMb      = flag.Float64("pod-recommendation-min-jvmheap-mb", 0, `Minimum JVM Heap recommendation for a pod`)
 	targetCPUPercentile  = flag.Float64("target-cpu-percentile", 0.9, "CPU usage percentile that will be used as a base for CPU target recommendation. Doesn't affect CPU lower bound, CPU upper bound nor memory recommendations.")

--- a/vertical-pod-autoscaler/pkg/recommender/logic/recommender_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/recommender_test.go
@@ -66,7 +66,7 @@ func TestMinResourcesSplitAcrossContainers(t *testing.T) {
 func TestControlledResourcesFiltered(t *testing.T) {
 	constEstimator := NewConstEstimator(model.Resources{
 		model.ResourceCPU:    model.CPUAmountFromCores(0.001),
-		model.ResourceMemory: model.MemoryAmountFromBytes(0),
+		model.ResourceMemory: model.MemoryAmountFromBytes(1e6),
 	})
 	recommender := podResourceRecommender{
 		constEstimator,
@@ -92,7 +92,7 @@ func TestControlledResourcesFiltered(t *testing.T) {
 func TestControlledResourcesFilteredDefault(t *testing.T) {
 	constEstimator := NewConstEstimator(model.Resources{
 		model.ResourceCPU:    model.CPUAmountFromCores(0.001),
-		model.ResourceMemory: model.MemoryAmountFromBytes(0),
+		model.ResourceMemory: model.MemoryAmountFromBytes(1e6),
 	})
 	recommender := podResourceRecommender{
 		constEstimator,

--- a/vertical-pod-autoscaler/pkg/recommender/logic/recommender_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/recommender_test.go
@@ -25,7 +25,7 @@ import (
 func TestMinResourcesApplied(t *testing.T) {
 	constEstimator := NewConstEstimator(model.Resources{
 		model.ResourceCPU:    model.CPUAmountFromCores(0.001),
-		model.ResourceMemory: model.MemoryAmountFromBytes(1e6),
+		model.ResourceMemory: model.MemoryAmountFromBytes(0),
 	})
 	recommender := podResourceRecommender{
 		constEstimator,
@@ -44,7 +44,7 @@ func TestMinResourcesApplied(t *testing.T) {
 func TestMinResourcesSplitAcrossContainers(t *testing.T) {
 	constEstimator := NewConstEstimator(model.Resources{
 		model.ResourceCPU:    model.CPUAmountFromCores(0.001),
-		model.ResourceMemory: model.MemoryAmountFromBytes(1e6),
+		model.ResourceMemory: model.MemoryAmountFromBytes(0),
 	})
 	recommender := podResourceRecommender{
 		constEstimator,
@@ -66,7 +66,7 @@ func TestMinResourcesSplitAcrossContainers(t *testing.T) {
 func TestControlledResourcesFiltered(t *testing.T) {
 	constEstimator := NewConstEstimator(model.Resources{
 		model.ResourceCPU:    model.CPUAmountFromCores(0.001),
-		model.ResourceMemory: model.MemoryAmountFromBytes(1e6),
+		model.ResourceMemory: model.MemoryAmountFromBytes(0),
 	})
 	recommender := podResourceRecommender{
 		constEstimator,
@@ -92,7 +92,7 @@ func TestControlledResourcesFiltered(t *testing.T) {
 func TestControlledResourcesFilteredDefault(t *testing.T) {
 	constEstimator := NewConstEstimator(model.Resources{
 		model.ResourceCPU:    model.CPUAmountFromCores(0.001),
-		model.ResourceMemory: model.MemoryAmountFromBytes(1e6),
+		model.ResourceMemory: model.MemoryAmountFromBytes(0),
 	})
 	recommender := podResourceRecommender{
 		constEstimator,


### PR DESCRIPTION
Sets the min WSS memory recommendation as 0, instead of 250MB. This is so we can differentiate real WSS recommendations from just the default min ones.