### PR TITLE
Add committed suffix to all JVM heap vars

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client.go
@@ -118,9 +118,9 @@ func calculateUsage(containerUsage k8sapiv1.ResourceList) model.Resources {
 	jvmHeapCommittedBytes := jvmHeapCommittedQuantity.Value()
 
 	return model.Resources{
-		model.ResourceCPU:     model.ResourceAmount(cpuMillicores),
-		model.ResourceMemory:  model.ResourceAmount(memoryBytes),
-		model.ResourceRSS:     model.ResourceAmount(rssBytes),
+		model.ResourceCPU:              model.ResourceAmount(cpuMillicores),
+		model.ResourceMemory:           model.ResourceAmount(memoryBytes),
+		model.ResourceRSS:              model.ResourceAmount(rssBytes),
 		model.ResourceJVMHeapCommitted: model.ResourceAmount(jvmHeapCommittedBytes),
 	}
 }

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client.go
@@ -114,13 +114,13 @@ func calculateUsage(containerUsage k8sapiv1.ResourceList) model.Resources {
 	rssQuantity := containerUsage[k8sapiv1.ResourceName(model.ResourceRSS)]
 	rssBytes := rssQuantity.Value()
 
-	jvmHeapQuantity := containerUsage[k8sapiv1.ResourceName(model.ResourceJVMHeap)]
-	jvmHeapBytes := jvmHeapQuantity.Value()
+	jvmHeapCommittedQuantity := containerUsage[k8sapiv1.ResourceName(model.ResourceJVMHeapCommitted)]
+	jvmHeapCommittedBytes := jvmHeapCommittedQuantity.Value()
 
 	return model.Resources{
 		model.ResourceCPU:     model.ResourceAmount(cpuMillicores),
 		model.ResourceMemory:  model.ResourceAmount(memoryBytes),
 		model.ResourceRSS:     model.ResourceAmount(rssBytes),
-		model.ResourceJVMHeap: model.ResourceAmount(jvmHeapBytes),
+		model.ResourceJVMHeapCommitted: model.ResourceAmount(jvmHeapCommittedBytes),
 	}
 }

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client_test_util.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client_test_util.go
@@ -74,9 +74,9 @@ func (tc *metricsClientTestCase) newContainerMetricsSnapshot(id model.ContainerI
 		SnapshotTime:   tc.snapshotTimestamp,
 		SnapshotWindow: tc.snapshotWindow,
 		Usage: model.Resources{
-			model.ResourceCPU:     model.ResourceAmount(cpuUsage),
-			model.ResourceMemory:  model.ResourceAmount(memUsage),
-			model.ResourceRSS:     0,
+			model.ResourceCPU:              model.ResourceAmount(cpuUsage),
+			model.ResourceMemory:           model.ResourceAmount(memUsage),
+			model.ResourceRSS:              0,
 			model.ResourceJVMHeapCommitted: 0,
 		},
 	}
@@ -135,9 +135,9 @@ func calculateResourceList(usage model.Resources) k8sapiv1.ResourceList {
 	jvmHeapCommittedQuantityString := jvmHeapCommittedBytes.String()
 
 	resourceMap := map[k8sapiv1.ResourceName]resource.Quantity{
-		k8sapiv1.ResourceCPU:                         resource.MustParse(cpuQuantityString),
-		k8sapiv1.ResourceMemory:                      resource.MustParse(memoryQuantityString),
-		k8sapiv1.ResourceName(model.ResourceRSS):     resource.MustParse(rssQuantityString),
+		k8sapiv1.ResourceCPU:                                  resource.MustParse(cpuQuantityString),
+		k8sapiv1.ResourceMemory:                               resource.MustParse(memoryQuantityString),
+		k8sapiv1.ResourceName(model.ResourceRSS):              resource.MustParse(rssQuantityString),
 		k8sapiv1.ResourceName(model.ResourceJVMHeapCommitted): resource.MustParse(jvmHeapCommittedQuantityString),
 	}
 	return k8sapiv1.ResourceList(resourceMap)

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client_test_util.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client_test_util.go
@@ -77,7 +77,7 @@ func (tc *metricsClientTestCase) newContainerMetricsSnapshot(id model.ContainerI
 			model.ResourceCPU:     model.ResourceAmount(cpuUsage),
 			model.ResourceMemory:  model.ResourceAmount(memUsage),
 			model.ResourceRSS:     0,
-			model.ResourceJVMHeap: 0,
+			model.ResourceJVMHeapCommitted: 0,
 		},
 	}
 }
@@ -131,14 +131,14 @@ func calculateResourceList(usage model.Resources) k8sapiv1.ResourceList {
 	rssBytes := big.NewInt(int64(usage[model.ResourceRSS]))
 	rssQuantityString := rssBytes.String()
 
-	jvmHeapBytes := big.NewInt(int64(usage[model.ResourceJVMHeap]))
-	jvmHeapQuantityString := jvmHeapBytes.String()
+	jvmHeapCommittedBytes := big.NewInt(int64(usage[model.ResourceJVMHeapCommitted]))
+	jvmHeapCommittedQuantityString := jvmHeapCommittedBytes.String()
 
 	resourceMap := map[k8sapiv1.ResourceName]resource.Quantity{
 		k8sapiv1.ResourceCPU:                         resource.MustParse(cpuQuantityString),
 		k8sapiv1.ResourceMemory:                      resource.MustParse(memoryQuantityString),
 		k8sapiv1.ResourceName(model.ResourceRSS):     resource.MustParse(rssQuantityString),
-		k8sapiv1.ResourceName(model.ResourceJVMHeap): resource.MustParse(jvmHeapQuantityString),
+		k8sapiv1.ResourceName(model.ResourceJVMHeapCommitted): resource.MustParse(jvmHeapCommittedQuantityString),
 	}
 	return k8sapiv1.ResourceList(resourceMap)
 }

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
@@ -77,7 +77,7 @@ func (s podMetricsSource) withM3CustomMetrics(podMetrics *v1beta1.PodMetricsList
 	for i, pod := range podMetrics.Items {
 		for j, container := range pod.Containers {
 			queries := map[string]k8sapiv1.ResourceName{
-				getRSSQuery(container.Name, pod.Name, pod.Namespace):     k8sapiv1.ResourceName(model.ResourceRSS),
+				getRSSQuery(container.Name, pod.Name, pod.Namespace):              k8sapiv1.ResourceName(model.ResourceRSS),
 				getJVMHeapCommittedQuery(container.Name, pod.Name, pod.Namespace): k8sapiv1.ResourceName(model.ResourceJVMHeapCommitted),
 			}
 			for query, resourceName := range queries {

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
@@ -61,7 +61,7 @@ func getRSSQuery(containerName string, podName string, namespace string) string 
 	return fmt.Sprintf("max_over_time(container_memory_rss{container_name='%s', pod_name='%s', namespace='%s'}[5m])", containerName, podName, namespace)
 }
 
-func getJVMHeapQuery(containerName string, podName string, namespace string) string {
+func getJVMHeapCommittedQuery(containerName string, podName string, namespace string) string {
 	return fmt.Sprintf("max_over_time(jmx_Memory_HeapMemoryUsage_committed{kubernetes_container_name='%s', kubernetes_pod_name='%s', kubernetes_namespace='%s'}[5m])", containerName, podName, namespace)
 }
 
@@ -78,7 +78,7 @@ func (s podMetricsSource) withM3CustomMetrics(podMetrics *v1beta1.PodMetricsList
 		for j, container := range pod.Containers {
 			queries := map[string]k8sapiv1.ResourceName{
 				getRSSQuery(container.Name, pod.Name, pod.Namespace):     k8sapiv1.ResourceName(model.ResourceRSS),
-				getJVMHeapQuery(container.Name, pod.Name, pod.Namespace): k8sapiv1.ResourceName(model.ResourceJVMHeap),
+				getJVMHeapCommittedQuery(container.Name, pod.Name, pod.Namespace): k8sapiv1.ResourceName(model.ResourceJVMHeapCommitted),
 			}
 			for query, resourceName := range queries {
 				params := url.Values{}

--- a/vertical-pod-autoscaler/pkg/recommender/logic/estimator.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/estimator.go
@@ -101,7 +101,7 @@ func (e *percentileEstimator) GetResourceEstimation(s *model.AggregateContainerS
 		model.ResourceMemory: model.MemoryAmountFromBytes(
 			s.AggregateMemoryPeaks.Percentile(e.memoryPercentile)),
 		// TODO: Take percentile once RSS + JVM Heap aggregation moves away from the naive max to by histogram.
-		model.ResourceRSS:     model.MemoryAmountFromBytes(s.RSSBytes),
+		model.ResourceRSS:              model.MemoryAmountFromBytes(s.RSSBytes),
 		model.ResourceJVMHeapCommitted: model.MemoryAmountFromBytes(s.JVMHeapCommittedBytes),
 	}
 }

--- a/vertical-pod-autoscaler/pkg/recommender/logic/estimator.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/estimator.go
@@ -102,7 +102,7 @@ func (e *percentileEstimator) GetResourceEstimation(s *model.AggregateContainerS
 			s.AggregateMemoryPeaks.Percentile(e.memoryPercentile)),
 		// TODO: Take percentile once RSS + JVM Heap aggregation moves away from the naive max to by histogram.
 		model.ResourceRSS:     model.MemoryAmountFromBytes(s.RSSBytes),
-		model.ResourceJVMHeap: model.MemoryAmountFromBytes(s.JVMHeapBytes),
+		model.ResourceJVMHeapCommitted: model.MemoryAmountFromBytes(s.JVMHeapCommittedBytes),
 	}
 }
 

--- a/vertical-pod-autoscaler/pkg/recommender/logic/recommender.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/recommender.go
@@ -29,7 +29,7 @@ var (
 	podMinCPUMillicores  = flag.Float64("pod-recommendation-min-cpu-millicores", 25, `Minimum CPU recommendation for a pod`)
 	podMinMemoryMb       = flag.Float64("pod-recommendation-min-memory-mb", 0, `Minimum memory recommendation for a pod`)
 	podMinRSSMb          = flag.Float64("pod-recommendation-min-rss-mb", 0, `Minimum RSS recommendation for a pod`)
-	podMinJVMHeapMb      = flag.Float64("pod-recommendation-min-jvmheap-mb", 0, `Minimum JVM Heap recommendation for a pod`)
+	podMinJVMHeapCommittedMb      = flag.Float64("pod-recommendation-min-jvmheapcommitted-mb", 0, `Minimum committed JVM Heap recommendation for a pod`)
 	targetCPUPercentile  = flag.Float64("target-cpu-percentile", 0.9, "CPU usage percentile that will be used as a base for CPU target recommendation. Doesn't affect CPU lower bound, CPU upper bound nor memory recommendations.")
 )
 
@@ -69,7 +69,7 @@ func (r *podResourceRecommender) GetRecommendedPodResources(containerNameToAggre
 		model.ResourceCPU:     model.ScaleResource(model.CPUAmountFromCores(*podMinCPUMillicores*0.001), fraction),
 		model.ResourceMemory:  model.ScaleResource(model.MemoryAmountFromBytes(*podMinMemoryMb*1024*1024), fraction),
 		model.ResourceRSS:     model.ScaleResource(model.MemoryAmountFromBytes(*podMinRSSMb*1024*1024), fraction),
-		model.ResourceJVMHeap: model.ScaleResource(model.MemoryAmountFromBytes(*podMinJVMHeapMb*1024*1024), fraction),
+		model.ResourceJVMHeapCommitted: model.ScaleResource(model.MemoryAmountFromBytes(*podMinJVMHeapCommittedMb*1024*1024), fraction),
 	}
 
 	recommender := &podResourceRecommender{

--- a/vertical-pod-autoscaler/pkg/recommender/logic/recommender.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/recommender.go
@@ -25,12 +25,12 @@ import (
 )
 
 var (
-	safetyMarginFraction = flag.Float64("recommendation-margin-fraction", 0.15, `Fraction of usage added as the safety margin to the recommended request`)
-	podMinCPUMillicores  = flag.Float64("pod-recommendation-min-cpu-millicores", 25, `Minimum CPU recommendation for a pod`)
-	podMinMemoryMb       = flag.Float64("pod-recommendation-min-memory-mb", 0, `Minimum memory recommendation for a pod`)
-	podMinRSSMb          = flag.Float64("pod-recommendation-min-rss-mb", 0, `Minimum RSS recommendation for a pod`)
-	podMinJVMHeapCommittedMb      = flag.Float64("pod-recommendation-min-jvmheapcommitted-mb", 0, `Minimum committed JVM Heap recommendation for a pod`)
-	targetCPUPercentile  = flag.Float64("target-cpu-percentile", 0.9, "CPU usage percentile that will be used as a base for CPU target recommendation. Doesn't affect CPU lower bound, CPU upper bound nor memory recommendations.")
+	safetyMarginFraction     = flag.Float64("recommendation-margin-fraction", 0.15, `Fraction of usage added as the safety margin to the recommended request`)
+	podMinCPUMillicores      = flag.Float64("pod-recommendation-min-cpu-millicores", 25, `Minimum CPU recommendation for a pod`)
+	podMinMemoryMb           = flag.Float64("pod-recommendation-min-memory-mb", 0, `Minimum memory recommendation for a pod`)
+	podMinRSSMb              = flag.Float64("pod-recommendation-min-rss-mb", 0, `Minimum RSS recommendation for a pod`)
+	podMinJVMHeapCommittedMb = flag.Float64("pod-recommendation-min-jvmheapcommitted-mb", 0, `Minimum committed JVM Heap recommendation for a pod`)
+	targetCPUPercentile      = flag.Float64("target-cpu-percentile", 0.9, "CPU usage percentile that will be used as a base for CPU target recommendation. Doesn't affect CPU lower bound, CPU upper bound nor memory recommendations.")
 )
 
 // PodResourceRecommender computes resource recommendation for a Vpa object.
@@ -66,9 +66,9 @@ func (r *podResourceRecommender) GetRecommendedPodResources(containerNameToAggre
 
 	fraction := 1.0 / float64(len(containerNameToAggregateStateMap))
 	minResources := model.Resources{
-		model.ResourceCPU:     model.ScaleResource(model.CPUAmountFromCores(*podMinCPUMillicores*0.001), fraction),
-		model.ResourceMemory:  model.ScaleResource(model.MemoryAmountFromBytes(*podMinMemoryMb*1024*1024), fraction),
-		model.ResourceRSS:     model.ScaleResource(model.MemoryAmountFromBytes(*podMinRSSMb*1024*1024), fraction),
+		model.ResourceCPU:              model.ScaleResource(model.CPUAmountFromCores(*podMinCPUMillicores*0.001), fraction),
+		model.ResourceMemory:           model.ScaleResource(model.MemoryAmountFromBytes(*podMinMemoryMb*1024*1024), fraction),
+		model.ResourceRSS:              model.ScaleResource(model.MemoryAmountFromBytes(*podMinRSSMb*1024*1024), fraction),
 		model.ResourceJVMHeapCommitted: model.ScaleResource(model.MemoryAmountFromBytes(*podMinJVMHeapCommittedMb*1024*1024), fraction),
 	}
 

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
@@ -181,11 +181,11 @@ func (a *AggregateContainerState) MergeContainerState(other *AggregateContainerS
 func NewAggregateContainerState() *AggregateContainerState {
 	config := GetAggregationsConfig()
 	return &AggregateContainerState{
-		AggregateCPUUsage:    util.NewDecayingHistogram(config.CPUHistogramOptions, config.CPUHistogramDecayHalfLife),
-		AggregateMemoryPeaks: util.NewDecayingHistogram(config.MemoryHistogramOptions, config.MemoryHistogramDecayHalfLife),
-		RSSBytes:             0,
-		JVMHeapCommittedBytes:         0,
-		CreationTime:         time.Now(),
+		AggregateCPUUsage:     util.NewDecayingHistogram(config.CPUHistogramOptions, config.CPUHistogramDecayHalfLife),
+		AggregateMemoryPeaks:  util.NewDecayingHistogram(config.MemoryHistogramOptions, config.MemoryHistogramDecayHalfLife),
+		RSSBytes:              0,
+		JVMHeapCommittedBytes: 0,
+		CreationTime:          time.Now(),
 	}
 }
 

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
@@ -60,8 +60,8 @@ const (
 
 var (
 	// DefaultControlledResources is a default value of Spec.ResourcePolicy.ContainerPolicies[].ControlledResources.
-	// TODO: Remove ResourceRSS/JVMHeap from default (requires updating all our VPAs to include ResourceRSS/JVMHeap in container policies).
-	DefaultControlledResources = []ResourceName{ResourceCPU, ResourceMemory, ResourceRSS, ResourceJVMHeap}
+	// TODO: Remove ResourceRSS/JVMHeapCommitted from default (requires updating all our VPAs to include ResourceRSS/JVMHeapCommitted in container policies).
+	DefaultControlledResources = []ResourceName{ResourceCPU, ResourceMemory, ResourceRSS, ResourceJVMHeapCommitted}
 )
 
 // ContainerStateAggregator is an interface for objects that consume and
@@ -98,9 +98,9 @@ type AggregateContainerState struct {
 	// RSSBytes is the max 5m-average RSS observed of all RSS samples (naive implementation).
 	// TODO: Aggregate properly with histogram once VPACheckpoint updated to support additional histogram.
 	RSSBytes float64
-	// JVMHeapBytes is the max 5m-average committed JVM Heap observed of all JVM Heap samples (naive implementation).
+	// JVMHeapCommittedBytes is the max 5m-average committed JVM Heap observed of all JVM Heap samples (naive implementation).
 	// TODO: Aggregate properly with histogram once VPACheckpoint updated to support additional histogram.
-	JVMHeapBytes float64
+	JVMHeapCommittedBytes float64
 	// Note: first/last sample timestamps as well as the sample count are based only on CPU samples.
 	FirstSampleStart  time.Time
 	LastSampleStart   time.Time
@@ -165,7 +165,7 @@ func (a *AggregateContainerState) MergeContainerState(other *AggregateContainerS
 	a.AggregateCPUUsage.Merge(other.AggregateCPUUsage)
 	a.AggregateMemoryPeaks.Merge(other.AggregateMemoryPeaks)
 	a.RSSBytes = math.Max(a.RSSBytes, other.RSSBytes)
-	a.JVMHeapBytes = math.Max(a.JVMHeapBytes, other.JVMHeapBytes)
+	a.JVMHeapCommittedBytes = math.Max(a.JVMHeapCommittedBytes, other.JVMHeapCommittedBytes)
 
 	if a.FirstSampleStart.IsZero() ||
 		(!other.FirstSampleStart.IsZero() && other.FirstSampleStart.Before(a.FirstSampleStart)) {
@@ -184,7 +184,7 @@ func NewAggregateContainerState() *AggregateContainerState {
 		AggregateCPUUsage:    util.NewDecayingHistogram(config.CPUHistogramOptions, config.CPUHistogramDecayHalfLife),
 		AggregateMemoryPeaks: util.NewDecayingHistogram(config.MemoryHistogramOptions, config.MemoryHistogramDecayHalfLife),
 		RSSBytes:             0,
-		JVMHeapBytes:         0,
+		JVMHeapCommittedBytes:         0,
 		CreationTime:         time.Now(),
 	}
 }
@@ -198,8 +198,8 @@ func (a *AggregateContainerState) AddSample(sample *ContainerUsageSample) {
 		a.AggregateMemoryPeaks.AddSample(BytesFromMemoryAmount(sample.Usage), 1.0, sample.MeasureStart)
 	case ResourceRSS:
 		a.addRSSSample(sample)
-	case ResourceJVMHeap:
-		a.addJVMHeapSample(sample)
+	case ResourceJVMHeapCommitted:
+		a.addJVMHeapCommittedSample(sample)
 	default:
 		panic(fmt.Sprintf("AddSample doesn't support resource '%s'", sample.Resource))
 	}
@@ -249,10 +249,10 @@ func (a *AggregateContainerState) addRSSSample(sample *ContainerUsageSample) {
 	a.TotalSamplesCount++
 }
 
-func (a *AggregateContainerState) addJVMHeapSample(sample *ContainerUsageSample) {
-	// JVMHeapBytes is the max 5m-average committed JVM Heap observed of all JVM Heap samples (naive implementation).
+func (a *AggregateContainerState) addJVMHeapCommittedSample(sample *ContainerUsageSample) {
+	// JVMHeapCommittedBytes is the max 5m-average committed JVM Heap observed of all JVM Heap samples (naive implementation).
 	// TODO: Aggregate properly with histogram once VPACheckpoint updated to support additional histogram.
-	a.JVMHeapBytes = math.Max(a.JVMHeapBytes, BytesFromMemoryAmount(sample.Usage))
+	a.JVMHeapCommittedBytes = math.Max(a.JVMHeapCommittedBytes, BytesFromMemoryAmount(sample.Usage))
 	if sample.MeasureStart.After(a.LastSampleStart) {
 		a.LastSampleStart = sample.MeasureStart
 	}

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state_test.go
@@ -279,11 +279,11 @@ func TestUpdateFromPolicyControlledResources(t *testing.T) {
 		}, {
 			name:     "No ControlledResources specified - used default",
 			policy:   &vpa_types.ContainerResourcePolicy{},
-			expected: []ResourceName{ResourceCPU, ResourceMemory, ResourceRSS, ResourceJVMHeap},
+			expected: []ResourceName{ResourceCPU, ResourceMemory, ResourceRSS, ResourceJVMHeapCommitted},
 		}, {
 			name:     "Nil policy - use default",
 			policy:   nil,
-			expected: []ResourceName{ResourceCPU, ResourceMemory, ResourceRSS, ResourceJVMHeap},
+			expected: []ResourceName{ResourceCPU, ResourceMemory, ResourceRSS, ResourceJVMHeapCommitted},
 		},
 	}
 	for _, tc := range testCases {

--- a/vertical-pod-autoscaler/pkg/recommender/model/container.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/container.go
@@ -68,13 +68,13 @@ type ContainerState struct {
 // NewContainerState returns a new ContainerState.
 func NewContainerState(request Resources, aggregator ContainerStateAggregator) *ContainerState {
 	return &ContainerState{
-		Request:                request,
-		LastCPUSampleStart:     time.Time{},
-		WindowEnd:              time.Time{},
-		lastMemorySampleStart:  time.Time{},
-		lastRSSSampleStart:     time.Time{},
+		Request:                         request,
+		LastCPUSampleStart:              time.Time{},
+		WindowEnd:                       time.Time{},
+		lastMemorySampleStart:           time.Time{},
+		lastRSSSampleStart:              time.Time{},
 		lastJVMHeapCommittedSampleStart: time.Time{},
-		aggregator:             aggregator,
+		aggregator:                      aggregator,
 	}
 }
 

--- a/vertical-pod-autoscaler/pkg/recommender/model/container.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/container.go
@@ -60,7 +60,7 @@ type ContainerState struct {
 	// Start of the latest RSS sample that was aggregated.
 	lastRSSSampleStart time.Time
 	// Start of the latest JVM Heap sample that was aggregated.
-	lastJVMHeapSampleStart time.Time
+	lastJVMHeapCommittedSampleStart time.Time
 	// Aggregation to add usage samples to.
 	aggregator ContainerStateAggregator
 }
@@ -73,7 +73,7 @@ func NewContainerState(request Resources, aggregator ContainerStateAggregator) *
 		WindowEnd:              time.Time{},
 		lastMemorySampleStart:  time.Time{},
 		lastRSSSampleStart:     time.Time{},
-		lastJVMHeapSampleStart: time.Time{},
+		lastJVMHeapCommittedSampleStart: time.Time{},
 		aggregator:             aggregator,
 	}
 }
@@ -104,14 +104,14 @@ func (container *ContainerState) addRSSSample(sample *ContainerUsageSample) bool
 	return true
 }
 
-func (container *ContainerState) addJVMHeapSample(sample *ContainerUsageSample) bool {
-	if !sample.isValid(ResourceJVMHeap) || !sample.MeasureStart.After(container.lastJVMHeapSampleStart) {
+func (container *ContainerState) addJVMHeapCommittedSample(sample *ContainerUsageSample) bool {
+	if !sample.isValid(ResourceJVMHeapCommitted) || !sample.MeasureStart.After(container.lastJVMHeapCommittedSampleStart) {
 		return false // Discard invalid, duplicate or out-of-order samples.
 	}
 	// TODO: Observe quality metrics once JVM Heap aggregation moves away from the naive max to by histogram.
-	// container.observeQualityMetrics(sample.Usage, false, corev1.ResourceName(ResourceJVMHeap))
+	// container.observeQualityMetrics(sample.Usage, false, corev1.ResourceName(ResourceJVMHeapCommitted))
 	container.aggregator.AddSample(sample)
-	container.lastJVMHeapSampleStart = sample.MeasureStart
+	container.lastJVMHeapCommittedSampleStart = sample.MeasureStart
 	return true
 }
 
@@ -249,8 +249,8 @@ func (container *ContainerState) AddSample(sample *ContainerUsageSample) bool {
 		return container.addMemorySample(sample, false)
 	case ResourceRSS:
 		return container.addRSSSample(sample)
-	case ResourceJVMHeap:
-		return container.addJVMHeapSample(sample)
+	case ResourceJVMHeapCommitted:
+		return container.addJVMHeapCommittedSample(sample)
 	default:
 		return false
 	}

--- a/vertical-pod-autoscaler/pkg/recommender/model/types.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/types.go
@@ -41,8 +41,8 @@ const (
 	ResourceMemory ResourceName = "memory"
 	// ResourceRSS represents RSS, in bytes.
 	ResourceRSS ResourceName = "rss"
-	// ResourceJVMHeap represents committed JVM Heap, in bytes.
-	ResourceJVMHeap ResourceName = "jvmHeapCommitted"
+	// ResourceJVMHeapCommitted represents committed JVM Heap, in bytes.
+	ResourceJVMHeapCommitted ResourceName = "jvmHeapCommitted"
 	// MaxResourceAmount is the maximum allowed value of resource amount.
 	MaxResourceAmount = ResourceAmount(1e14)
 )
@@ -98,8 +98,8 @@ func ResourcesAsResourceList(resources Resources) apiv1.ResourceList {
 		case ResourceRSS:
 			newKey = apiv1.ResourceName(ResourceRSS)
 			quantity = QuantityFromMemoryAmount(resourceAmount)
-		case ResourceJVMHeap:
-			newKey = apiv1.ResourceName(ResourceJVMHeap)
+		case ResourceJVMHeapCommitted:
+			newKey = apiv1.ResourceName(ResourceJVMHeapCommitted)
 			quantity = QuantityFromMemoryAmount(resourceAmount)
 		default:
 			klog.Errorf("Cannot translate %v resource name", key)
@@ -121,8 +121,8 @@ func ResourceNamesApiToModel(resources []apiv1.ResourceName) *[]ResourceName {
 			result = append(result, ResourceMemory)
 		case apiv1.ResourceName(ResourceRSS):
 			result = append(result, ResourceRSS)
-		case apiv1.ResourceName(ResourceJVMHeap):
-			result = append(result, ResourceJVMHeap)
+		case apiv1.ResourceName(ResourceJVMHeapCommitted):
+			result = append(result, ResourceJVMHeapCommitted)
 		default:
 			klog.Errorf("Cannot translate %v resource name", resource)
 			continue


### PR DESCRIPTION
Nit to add the `committed` suffix to all JVM heap variables. Follow-up to https://github.com/jodzga/autoscaler/pull/9#pullrequestreview-1998428883, where only the name of the field was changed instead of all the vars.