### PR TITLE
Add RSS and JVM heap histograms to v1 VPACheckpoint object status

### DIFF
--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
@@ -396,6 +396,12 @@ type VerticalPodAutoscalerCheckpointStatus struct {
 	// Checkpoint of histogram for consumption of memory.
 	MemoryHistogram HistogramCheckpoint `json:"memoryHistogram,omitempty" protobuf:"bytes,4,rep,name=memoryHistogram"`
 
+	// Checkpoint of histogram for consumption of RSS.
+	RSSHistogram HistogramCheckpoint `json:"rssHistogram,omitempty" protobuf:"bytes,5,rep,name=rssHistogram"`
+
+	// Checkpoint of histogram for consumption of committed JVM heap.
+	JVMHeapCommittedHistogram HistogramCheckpoint `json:"jvmHeapCommittedHistogram,omitempty" protobuf:"bytes,6,rep,name=jvmHeapCommittedHistogram"`
+
 	// Timestamp of the fist sample from the histograms.
 	// +nullable
 	FirstSampleStart metav1.Time `json:"firstSampleStart,omitempty" protobuf:"bytes,5,opt,name=firstSampleStart"`

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/zz_generated.deepcopy.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/zz_generated.deepcopy.go
@@ -328,7 +328,7 @@ func (in *VerticalPodAutoscalerCheckpointStatus) DeepCopyInto(out *VerticalPodAu
 	in.CPUHistogram.DeepCopyInto(&out.CPUHistogram)
 	in.MemoryHistogram.DeepCopyInto(&out.MemoryHistogram)
 	in.RSSHistogram.DeepCopyInto(&out.RSSHistogram)
-	in.jvmHeapCommittedHistogram.DeepCopyInto(&out.jvmHeapCommittedHistogram)
+	in.JVMHeapCommittedHistogram.DeepCopyInto(&out.JVMHeapCommittedHistogram)
 	in.FirstSampleStart.DeepCopyInto(&out.FirstSampleStart)
 	in.LastSampleStart.DeepCopyInto(&out.LastSampleStart)
 	return

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/zz_generated.deepcopy.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/zz_generated.deepcopy.go
@@ -327,6 +327,8 @@ func (in *VerticalPodAutoscalerCheckpointStatus) DeepCopyInto(out *VerticalPodAu
 	in.LastUpdateTime.DeepCopyInto(&out.LastUpdateTime)
 	in.CPUHistogram.DeepCopyInto(&out.CPUHistogram)
 	in.MemoryHistogram.DeepCopyInto(&out.MemoryHistogram)
+	in.RSSHistogram.DeepCopyInto(&out.RSSHistogram)
+	in.jvmHeapCommittedHistogram.DeepCopyInto(&out.jvmHeapCommittedHistogram)
 	in.FirstSampleStart.DeepCopyInto(&out.FirstSampleStart)
 	in.LastSampleStart.DeepCopyInto(&out.LastSampleStart)
 	return


### PR DESCRIPTION
Adds `JVMHeapCommittedHistogram` and `RSSHistogram` fields to `v1` `VerticalPodAutoscalerCheckpointStatus`. These will be used to track the distribution of historical samples of committed JVM heap and RSS, respectively. 