### PR TITLE
draft

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
+++ b/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
@@ -106,6 +106,9 @@ func (writer *checkpointWriter) StoreCheckpoints(ctx context.Context, now time.T
 				},
 				Status: *containerCheckpoint,
 			}
+			if vpa.ID.Namespace == "vpa-test-service" {
+				klog.Infof("vpa-test-service CHECKPOINT %+v", containerCheckpoint)
+			}
 			err = api_util.CreateOrUpdateVpaCheckpoint(writer.vpaCheckpointClient.VerticalPodAutoscalerCheckpoints(vpa.ID.Namespace), &vpaCheckpoint)
 			if err != nil {
 				klog.Errorf("Cannot save VPA %s/%s checkpoint for %s. Reason: %+v",

--- a/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
+++ b/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
@@ -144,9 +144,13 @@ func buildAggregateContainerStateMap(vpa *model.Vpa, cluster *model.ClusterState
 }
 
 func subtractCurrentContainerMemoryPeak(a *model.AggregateContainerState, container *model.ContainerState, now time.Time) {
-	if now.Before(container.WindowEnd) {
-		a.AggregateMemoryPeaks.SubtractSample(model.BytesFromMemoryAmount(container.GetMaxMemoryPeak()), 1.0, container.WindowEnd)
-		a.AggregateRSSPeaks.SubtractSample(model.BytesFromMemoryAmount(container.GetMaxRSSPeak()), 1.0, container.WindowEnd)
-		a.AggregateJVMHeapCommittedPeaks.SubtractSample(model.BytesFromMemoryAmount(container.GetMaxJVMHeapCommittedPeak()), 1.0, container.WindowEnd)
+	if now.Before(container.MemoryWindowEnd) {
+		a.AggregateMemoryPeaks.SubtractSample(model.BytesFromMemoryAmount(container.GetMaxMemoryPeak()), 1.0, container.MemoryWindowEnd)
+	}
+	if now.Before(container.RSSWindowEnd) {
+		a.AggregateRSSPeaks.SubtractSample(model.BytesFromMemoryAmount(container.GetMaxRSSPeak()), 1.0, container.RSSWindowEnd)
+	}
+	if now.Before(container.JVMHeapCommittedWindowEnd) {
+		a.AggregateJVMHeapCommittedPeaks.SubtractSample(model.BytesFromMemoryAmount(container.GetMaxJVMHeapCommittedPeak()), 1.0, container.JVMHeapCommittedWindowEnd)
 	}
 }

--- a/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
+++ b/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
@@ -146,5 +146,7 @@ func buildAggregateContainerStateMap(vpa *model.Vpa, cluster *model.ClusterState
 func subtractCurrentContainerMemoryPeak(a *model.AggregateContainerState, container *model.ContainerState, now time.Time) {
 	if now.Before(container.WindowEnd) {
 		a.AggregateMemoryPeaks.SubtractSample(model.BytesFromMemoryAmount(container.GetMaxMemoryPeak()), 1.0, container.WindowEnd)
+		a.AggregateRSSPeaks.SubtractSample(model.BytesFromMemoryAmount(container.GetMaxRSSPeak()), 1.0, container.WindowEnd)
+		a.AggregateJVMHeapCommittedPeaks.SubtractSample(model.BytesFromMemoryAmount(container.GetMaxJVMHeapCommittedPeak()), 1.0, container.WindowEnd)
 	}
 }

--- a/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
+++ b/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
@@ -141,9 +141,12 @@ func buildAggregateContainerStateMap(vpa *model.Vpa, cluster *model.ClusterState
 			if vpa.UsesAggregation(aggregateKey) {
 				if aggregateContainerState, exists := aggregateContainerStateMap[containerName]; exists {
 					if containerName == "vpa-test-service" {
-						klog.Infof("vpa-test-service aggregate container state %+v", aggregateContainerState)
+						klog.Infof("BEFORE vpa-test-service aggregate container state %+v", aggregateContainerState)
 					}
 					subtractCurrentContainerMemoryPeak(aggregateContainerState, container, now)
+					if containerName == "vpa-test-service" {
+						klog.Infof("AFTER vpa-test-service aggregate container state %+v", aggregateContainerState)
+					}
 				}
 			}
 		}

--- a/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
+++ b/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
@@ -140,6 +140,9 @@ func buildAggregateContainerStateMap(vpa *model.Vpa, cluster *model.ClusterState
 			aggregateKey := cluster.MakeAggregateStateKey(pod, containerName)
 			if vpa.UsesAggregation(aggregateKey) {
 				if aggregateContainerState, exists := aggregateContainerStateMap[containerName]; exists {
+					if containerName == "vpa-test-service" {
+						klog.Infof("vpa-test-service aggregate container state %+v", aggregateContainerState)
+					}
 					subtractCurrentContainerMemoryPeak(aggregateContainerState, container, now)
 				}
 			}

--- a/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
+++ b/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
@@ -114,8 +114,10 @@ func (writer *checkpointWriter) StoreCheckpoints(ctx context.Context, now time.T
 				klog.Errorf("Cannot save VPA %s/%s checkpoint for %s. Reason: %+v",
 					vpa.ID.Namespace, vpaCheckpoint.Spec.VPAObjectName, vpaCheckpoint.Spec.ContainerName, err)
 			} else {
-				klog.V(3).Infof("Saved VPA %s/%s checkpoint for %s",
-					vpa.ID.Namespace, vpaCheckpoint.Spec.VPAObjectName, vpaCheckpoint.Spec.ContainerName)
+				if vpa.ID.Namespace == "vpa-test-service" {
+					klog.V(3).Infof("Saved VPA %s/%s checkpoint for %s",
+						vpa.ID.Namespace, vpaCheckpoint.Spec.VPAObjectName, vpaCheckpoint.Spec.ContainerName)
+				}
 				vpa.CheckpointWritten = now
 			}
 			minCheckpoints--

--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -359,7 +359,7 @@ func (feeder *clusterStateFeeder) LoadVPAs() {
 		}
 
 		selector, conditions := feeder.getSelector(vpaCRD)
-		klog.V(4).Infof("Using selector %s for VPA %s/%s", selector.String(), vpaCRD.Namespace, vpaCRD.Name)
+		// klog.V(4).Infof("Using selector %s for VPA %s/%s", selector.String(), vpaCRD.Namespace, vpaCRD.Name)
 
 		if feeder.clusterState.AddOrUpdateVpa(vpaCRD, selector) == nil {
 			// Successfully added VPA to the model.
@@ -442,7 +442,7 @@ Loop:
 	for {
 		select {
 		case oomInfo := <-feeder.oomChan:
-			klog.V(3).Infof("OOM detected %+v", oomInfo)
+			// klog.V(3).Infof("OOM detected %+v", oomInfo)
 			if err = feeder.clusterState.RecordOOM(oomInfo.ContainerID, oomInfo.Timestamp, oomInfo.Memory); err != nil {
 				klog.Warningf("Failed to record OOM %+v. Reason: %+v", oomInfo, err)
 			}

--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -251,14 +251,14 @@ func (feeder *clusterStateFeeder) InitFromCheckpoints() {
 	}
 
 	for namespace := range namespaces {
-		klog.V(3).Infof("Fetching checkpoints from namespace %s", namespace)
+		// klog.V(3).Infof("Fetching checkpoints from namespace %s", namespace)
 		checkpointList, err := feeder.vpaCheckpointClient.VerticalPodAutoscalerCheckpoints(namespace).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			klog.Errorf("Cannot list VPA checkpoints from namespace %v. Reason: %+v", namespace, err)
 		}
 		for _, checkpoint := range checkpointList.Items {
 
-			klog.V(3).Infof("Loading VPA %s/%s checkpoint for %s", checkpoint.ObjectMeta.Namespace, checkpoint.Spec.VPAObjectName, checkpoint.Spec.ContainerName)
+			// klog.V(3).Infof("Loading VPA %s/%s checkpoint for %s", checkpoint.ObjectMeta.Namespace, checkpoint.Spec.VPAObjectName, checkpoint.Spec.ContainerName)
 			err = feeder.setVpaCheckpoint(&checkpoint)
 			if err != nil {
 				klog.Errorf("Error while loading checkpoint. Reason: %+v", err)

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
@@ -87,68 +87,68 @@ func (s podMetricsSource) withM3CustomMetrics(podMetrics *v1beta1.PodMetricsList
 
 				resp, err := http.Get(m3Url.String())
 				if err != nil {
-					klog.ErrorS(err, "Failed to query M3", "query", query)
+					// klog.ErrorS(err, "Failed to query M3", "query", query)
 					continue
 				}
 				if resp.StatusCode != http.StatusOK {
-					klog.ErrorS(err, "Failed to get valid response", "query", query, "status", resp.Status)
+					// klog.ErrorS(err, "Failed to get valid response", "query", query, "status", resp.Status)
 					continue
 				}
 
 				defer resp.Body.Close()
 				body, err := ioutil.ReadAll(resp.Body)
 				if err != nil {
-					klog.ErrorS(err, "Failed to read response body", "query", query)
+					// klog.ErrorS(err, "Failed to read response body", "query", query)
 					continue
 				}
 
 				var responseBody map[string]interface{}
 				if err := json.Unmarshal(body, &responseBody); err != nil {
-					klog.ErrorS(err, "Failed to unmarshal JSON", "body", string(body))
+					// klog.ErrorS(err, "Failed to unmarshal JSON", "body", string(body))
 					continue
 				}
 				data, ok := (responseBody["data"]).(map[string]interface{})
 				if !ok {
-					klog.Errorf("Failed to get .data from JSON: %+v", responseBody)
+					// klog.Errorf("Failed to get .data from JSON: %+v", responseBody)
 					continue
 				}
 				result, ok := (data["result"]).([]interface{})
 				if !ok {
-					klog.Errorf("Failed to get .data.result from JSON: %+v", responseBody)
+					// klog.Errorf("Failed to get .data.result from JSON: %+v", responseBody)
 					continue
 				}
 				if len(result) == 0 {
-					klog.Errorf("Failed to get any query results in .data.result: %+v", responseBody)
+					// klog.Errorf("Failed to get any query results in .data.result: %+v", responseBody)
 					continue
 				}
 				if len(result) > 1 {
-					klog.Errorf("More than one query result in .data.result: %+v", responseBody)
+					// klog.Errorf("More than one query result in .data.result: %+v", responseBody)
 					// Proceed for now and just use the first result. Will need to fine-tune the query if so.
 				}
 				firstResult, ok := (result[0]).(map[string]interface{})
 				if !ok {
-					klog.Errorf("Failed to get first element from .data.result: %+v", responseBody)
+					// klog.Errorf("Failed to get first element from .data.result: %+v", responseBody)
 					continue
 				}
 				value, ok := (firstResult["value"]).([]interface{})
 				if !ok {
-					klog.Errorf("Failed to get .data.result[0].value: %+v", responseBody)
+					// klog.Errorf("Failed to get .data.result[0].value: %+v", responseBody)
 					continue
 				}
 				resourceValue, ok := (value[1]).(string)
 				if !ok {
-					klog.Errorf("Failed to get .data.result[0].value[1]: %+v", responseBody)
+					// klog.Errorf("Failed to get .data.result[0].value[1]: %+v", responseBody)
 					continue
 				}
 
 				resourceQuantity, err := resource.ParseQuantity(resourceValue)
 				if err != nil {
-					klog.ErrorS(err, "Failed to parse as resource quantity", "resourceValue", resourceValue)
+					// klog.ErrorS(err, "Failed to parse as resource quantity", "resourceValue", resourceValue)
 					continue
 				}
 
 				podMetrics.Items[i].Containers[j].Usage[resourceName] = resourceQuantity
-				klog.InfoS("Added container usage data from M3", "resource", resourceName, "value", resourceQuantity, "container", container.Name, "pod", pod.Name, "namespace", pod.Namespace)
+				// klog.InfoS("Added container usage data from M3", "resource", resourceName, "value", resourceQuantity, "container", container.Name, "pod", pod.Name, "namespace", pod.Namespace)
 			}
 		}
 	}

--- a/vertical-pod-autoscaler/pkg/recommender/logic/estimator.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/estimator.go
@@ -100,9 +100,9 @@ func (e *percentileEstimator) GetResourceEstimation(s *model.AggregateContainerS
 			s.AggregateCPUUsage.Percentile(e.cpuPercentile)),
 		model.ResourceMemory: model.MemoryAmountFromBytes(
 			s.AggregateMemoryPeaks.Percentile(e.memoryPercentile)),
-		// TODO: Take percentile once RSS + JVM Heap aggregation moves away from the naive max to by histogram.
-		model.ResourceRSS:              model.MemoryAmountFromBytes(s.RSSBytes),
-		model.ResourceJVMHeapCommitted: model.MemoryAmountFromBytes(s.JVMHeapCommittedBytes),
+		// TODO: Use individual config for RSS and JVMHeapCommitted.
+		model.ResourceRSS:              model.MemoryAmountFromBytes(s.AggregateRSSPeaks.Percentile(e.memoryPercentile)),
+		model.ResourceJVMHeapCommitted: model.MemoryAmountFromBytes(s.AggregateJVMHeapCommittedPeaks.Percentile(e.memoryPercentile)),
 	}
 }
 

--- a/vertical-pod-autoscaler/pkg/recommender/logic/estimator_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/estimator_test.go
@@ -54,8 +54,10 @@ func TestPercentileEstimator(t *testing.T) {
 
 	resourceEstimation := estimator.GetResourceEstimation(
 		&model.AggregateContainerState{
-			AggregateCPUUsage:    cpuHistogram,
-			AggregateMemoryPeaks: memoryPeaksHistogram,
+			AggregateCPUUsage:              cpuHistogram,
+			AggregateMemoryPeaks:           memoryPeaksHistogram,
+			AggregateRSSPeaks:              memoryPeaksHistogram,
+			AggregateJVMHeapCommittedPeaks: memoryPeaksHistogram,
 		})
 	maxRelativeError := 0.05 // Allow 5% relative error to account for histogram rounding.
 	assert.InEpsilon(t, 1.0, model.CoresFromCPUAmount(resourceEstimation[model.ResourceCPU]), maxRelativeError)

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
@@ -95,12 +95,12 @@ type AggregateContainerState struct {
 	// AggregateMemoryPeaks is a distribution of memory peaks from all containers:
 	// each container should add one peak per memory aggregation interval (e.g. once every 24h).
 	AggregateMemoryPeaks util.Histogram
-	// RSSBytes is the max 5m-average RSS observed of all RSS samples (naive implementation).
-	// TODO: Aggregate properly with histogram once VPACheckpoint updated to support additional histogram.
-	RSSBytes float64
-	// JVMHeapCommittedBytes is the max 5m-average committed JVM Heap observed of all JVM Heap samples (naive implementation).
-	// TODO: Aggregate properly with histogram once VPACheckpoint updated to support additional histogram.
-	JVMHeapCommittedBytes float64
+	// AggregateRSSPeaks is a distribution of RSS peaks from all containers:
+	// each container should add one peak per memory aggregation interval (e.g. once every 24h).
+	AggregateRSSPeaks util.Histogram
+	// AggregateJVMHeapCommittedPeaks is a distribution of committed JVM heap peaks from all containers:
+	// each container should add one peak per memory aggregation interval (e.g. once every 24h).
+	AggregateJVMHeapCommittedPeaks util.Histogram
 	// Note: first/last sample timestamps as well as the sample count are based only on CPU samples.
 	FirstSampleStart  time.Time
 	LastSampleStart   time.Time
@@ -164,8 +164,8 @@ func (a *AggregateContainerState) MarkNotAutoscaled() {
 func (a *AggregateContainerState) MergeContainerState(other *AggregateContainerState) {
 	a.AggregateCPUUsage.Merge(other.AggregateCPUUsage)
 	a.AggregateMemoryPeaks.Merge(other.AggregateMemoryPeaks)
-	a.RSSBytes = math.Max(a.RSSBytes, other.RSSBytes)
-	a.JVMHeapCommittedBytes = math.Max(a.JVMHeapCommittedBytes, other.JVMHeapCommittedBytes)
+	a.AggregateRSSPeaks.Merge(other.AggregateRSSPeaks)
+	a.AggregateJVMHeapCommittedPeaks.Merge(other.AggregateJVMHeapCommittedPeaks)
 
 	if a.FirstSampleStart.IsZero() ||
 		(!other.FirstSampleStart.IsZero() && other.FirstSampleStart.Before(a.FirstSampleStart)) {
@@ -181,11 +181,12 @@ func (a *AggregateContainerState) MergeContainerState(other *AggregateContainerS
 func NewAggregateContainerState() *AggregateContainerState {
 	config := GetAggregationsConfig()
 	return &AggregateContainerState{
-		AggregateCPUUsage:     util.NewDecayingHistogram(config.CPUHistogramOptions, config.CPUHistogramDecayHalfLife),
-		AggregateMemoryPeaks:  util.NewDecayingHistogram(config.MemoryHistogramOptions, config.MemoryHistogramDecayHalfLife),
-		RSSBytes:              0,
-		JVMHeapCommittedBytes: 0,
-		CreationTime:          time.Now(),
+		AggregateCPUUsage:    util.NewDecayingHistogram(config.CPUHistogramOptions, config.CPUHistogramDecayHalfLife),
+		AggregateMemoryPeaks: util.NewDecayingHistogram(config.MemoryHistogramOptions, config.MemoryHistogramDecayHalfLife),
+		// TODO: Use individual config for RSS and JVMHeapCommitted.
+		AggregateRSSPeaks:              util.NewDecayingHistogram(config.MemoryHistogramOptions, config.MemoryHistogramDecayHalfLife),
+		AggregateJVMHeapCommittedPeaks: util.NewDecayingHistogram(config.MemoryHistogramOptions, config.MemoryHistogramDecayHalfLife),
+		CreationTime:                   time.Now(),
 	}
 }
 
@@ -197,9 +198,9 @@ func (a *AggregateContainerState) AddSample(sample *ContainerUsageSample) {
 	case ResourceMemory:
 		a.AggregateMemoryPeaks.AddSample(BytesFromMemoryAmount(sample.Usage), 1.0, sample.MeasureStart)
 	case ResourceRSS:
-		a.addRSSSample(sample)
+		a.AggregateRSSPeaks.AddSample(BytesFromMemoryAmount(sample.Usage), 1.0, sample.MeasureStart)
 	case ResourceJVMHeapCommitted:
-		a.addJVMHeapCommittedSample(sample)
+		a.AggregateJVMHeapCommittedPeaks.AddSample(BytesFromMemoryAmount(sample.Usage), 1.0, sample.MeasureStart)
 	default:
 		panic(fmt.Sprintf("AddSample doesn't support resource '%s'", sample.Resource))
 	}
@@ -214,6 +215,10 @@ func (a *AggregateContainerState) SubtractSample(sample *ContainerUsageSample) {
 	switch sample.Resource {
 	case ResourceMemory:
 		a.AggregateMemoryPeaks.SubtractSample(BytesFromMemoryAmount(sample.Usage), 1.0, sample.MeasureStart)
+	case ResourceRSS:
+		a.AggregateRSSPeaks.SubtractSample(BytesFromMemoryAmount(sample.Usage), 1.0, sample.MeasureStart)
+	case ResourceJVMHeapCommitted:
+		a.AggregateJVMHeapCommittedPeaks.SubtractSample(BytesFromMemoryAmount(sample.Usage), 1.0, sample.MeasureStart)
 	default:
 		panic(fmt.Sprintf("SubtractSample doesn't support resource '%s'", sample.Resource))
 	}
@@ -236,32 +241,6 @@ func (a *AggregateContainerState) addCPUSample(sample *ContainerUsageSample) {
 	a.TotalSamplesCount++
 }
 
-func (a *AggregateContainerState) addRSSSample(sample *ContainerUsageSample) {
-	// RSSBytes is the max 5m-average RSS observed of all RSS samples (naive implementation).
-	// TODO: Aggregate properly with histogram once VPACheckpoint updated to support additional histogram.
-	a.RSSBytes = math.Max(a.RSSBytes, BytesFromMemoryAmount(sample.Usage))
-	if sample.MeasureStart.After(a.LastSampleStart) {
-		a.LastSampleStart = sample.MeasureStart
-	}
-	if a.FirstSampleStart.IsZero() || sample.MeasureStart.Before(a.FirstSampleStart) {
-		a.FirstSampleStart = sample.MeasureStart
-	}
-	a.TotalSamplesCount++
-}
-
-func (a *AggregateContainerState) addJVMHeapCommittedSample(sample *ContainerUsageSample) {
-	// JVMHeapCommittedBytes is the max 5m-average committed JVM Heap observed of all JVM Heap samples (naive implementation).
-	// TODO: Aggregate properly with histogram once VPACheckpoint updated to support additional histogram.
-	a.JVMHeapCommittedBytes = math.Max(a.JVMHeapCommittedBytes, BytesFromMemoryAmount(sample.Usage))
-	if sample.MeasureStart.After(a.LastSampleStart) {
-		a.LastSampleStart = sample.MeasureStart
-	}
-	if a.FirstSampleStart.IsZero() || sample.MeasureStart.Before(a.FirstSampleStart) {
-		a.FirstSampleStart = sample.MeasureStart
-	}
-	a.TotalSamplesCount++
-}
-
 // SaveToCheckpoint serializes AggregateContainerState as VerticalPodAutoscalerCheckpointStatus.
 // The serialization may result in loss of precission of the histograms.
 func (a *AggregateContainerState) SaveToCheckpoint() (*vpa_types.VerticalPodAutoscalerCheckpointStatus, error) {
@@ -273,14 +252,24 @@ func (a *AggregateContainerState) SaveToCheckpoint() (*vpa_types.VerticalPodAuto
 	if err != nil {
 		return nil, err
 	}
+	rss, err := a.AggregateRSSPeaks.SaveToChekpoint()
+	if err != nil {
+		return nil, err
+	}
+	jvmHeapCommitted, err := a.AggregateJVMHeapCommittedPeaks.SaveToChekpoint()
+	if err != nil {
+		return nil, err
+	}
 	return &vpa_types.VerticalPodAutoscalerCheckpointStatus{
-		LastUpdateTime:    metav1.NewTime(time.Now()),
-		FirstSampleStart:  metav1.NewTime(a.FirstSampleStart),
-		LastSampleStart:   metav1.NewTime(a.LastSampleStart),
-		TotalSamplesCount: a.TotalSamplesCount,
-		MemoryHistogram:   *memory,
-		CPUHistogram:      *cpu,
-		Version:           SupportedCheckpointVersion,
+		LastUpdateTime:            metav1.NewTime(time.Now()),
+		FirstSampleStart:          metav1.NewTime(a.FirstSampleStart),
+		LastSampleStart:           metav1.NewTime(a.LastSampleStart),
+		TotalSamplesCount:         a.TotalSamplesCount,
+		MemoryHistogram:           *memory,
+		CPUHistogram:              *cpu,
+		RSSHistogram:              *rss,
+		JVMHeapCommittedHistogram: *jvmHeapCommitted,
+		Version:                   SupportedCheckpointVersion,
 	}, nil
 }
 
@@ -298,6 +287,14 @@ func (a *AggregateContainerState) LoadFromCheckpoint(checkpoint *vpa_types.Verti
 		return err
 	}
 	err = a.AggregateCPUUsage.LoadFromCheckpoint(&checkpoint.CPUHistogram)
+	if err != nil {
+		return err
+	}
+	err = a.AggregateRSSPeaks.LoadFromCheckpoint(&checkpoint.RSSHistogram)
+	if err != nil {
+		return err
+	}
+	err = a.AggregateJVMHeapCommittedPeaks.LoadFromCheckpoint(&checkpoint.JVMHeapCommittedHistogram)
 	if err != nil {
 		return err
 	}

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state_test.go
@@ -119,8 +119,8 @@ func TestAggregateStateByContainerName(t *testing.T) {
 	actualCPUHistogram := aggregateResources["app-A"].AggregateCPUUsage
 
 	expectedMemoryHistogram := util.NewDecayingHistogram(config.MemoryHistogramOptions, config.MemoryHistogramDecayHalfLife)
-	expectedMemoryHistogram.AddSample(2e9, 1.0, cluster.GetContainer(containers[0]).WindowEnd)
-	expectedMemoryHistogram.AddSample(4e9, 1.0, cluster.GetContainer(containers[2]).WindowEnd)
+	expectedMemoryHistogram.AddSample(2e9, 1.0, cluster.GetContainer(containers[0]).MemoryWindowEnd)
+	expectedMemoryHistogram.AddSample(4e9, 1.0, cluster.GetContainer(containers[2]).MemoryWindowEnd)
 	actualMemoryHistogram := aggregateResources["app-A"].AggregateMemoryPeaks
 
 	assert.True(t, expectedCPUHistogram.Equals(actualCPUHistogram), "Expected:\n%s\nActual:\n%s", expectedCPUHistogram, actualCPUHistogram)

--- a/vertical-pod-autoscaler/pkg/recommender/model/cluster.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/cluster.go
@@ -197,7 +197,7 @@ func (cluster *ClusterState) AddOrUpdateContainer(containerID ContainerID, reque
 	}
 	if container, containerExists := pod.Containers[containerID.ContainerName]; !containerExists {
 		cluster.findOrCreateAggregateContainerState(containerID)
-		pod.Containers[containerID.ContainerName] = NewContainerState(request, NewContainerStateAggregatorProxy(cluster, containerID))
+		pod.Containers[containerID.ContainerName] = NewContainerState(containerID.PodID.Namespace, request, NewContainerStateAggregatorProxy(cluster, containerID))
 	} else {
 		// Container aleady exists. Possibly update the request.
 		container.Request = request

--- a/vertical-pod-autoscaler/pkg/recommender/model/container.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/container.go
@@ -168,17 +168,15 @@ func (container *ContainerState) addMemorySample(sample *ContainerUsageSample, i
 	addNewPeak := false
 	if ts.Before(container.WindowEnd) {
 		oldMaxMem := container.GetMaxMemoryPeak()
-		if sample.Usage > oldMaxMem {
+		if oldMaxMem != 0 && sample.Usage > oldMaxMem {
 			// Remove the old peak.
-			if oldMaxMem != 0 {
-				oldPeak := ContainerUsageSample{
-					MeasureStart: container.WindowEnd,
-					Usage:        oldMaxMem,
-					Request:      sample.Request,
-					Resource:     ResourceMemory,
-				}
-				container.aggregator.SubtractSample(&oldPeak)
+			oldPeak := ContainerUsageSample{
+				MeasureStart: container.WindowEnd,
+				Usage:        oldMaxMem,
+				Request:      sample.Request,
+				Resource:     ResourceMemory,
 			}
+			container.aggregator.SubtractSample(&oldPeak)
 			addNewPeak = true
 		}
 	} else {
@@ -226,17 +224,15 @@ func (container *ContainerState) addRSSSample(sample *ContainerUsageSample, isOO
 	addNewPeak := false
 	if ts.Before(container.WindowEnd) {
 		oldMaxRss := container.GetMaxRSSPeak()
-		if sample.Usage > oldMaxRss {
+		if oldMaxRss != 0 && sample.Usage > oldMaxRss {
 			// Remove the old peak.
-			if oldMaxRss != 0 {
-				oldPeak := ContainerUsageSample{
-					MeasureStart: container.WindowEnd,
-					Usage:        oldMaxRss,
-					Request:      sample.Request,
-					Resource:     ResourceRSS,
-				}
-				container.aggregator.SubtractSample(&oldPeak)
+			oldPeak := ContainerUsageSample{
+				MeasureStart: container.WindowEnd,
+				Usage:        oldMaxRss,
+				Request:      sample.Request,
+				Resource:     ResourceRSS,
 			}
+			container.aggregator.SubtractSample(&oldPeak)
 			addNewPeak = true
 		}
 	} else {
@@ -279,17 +275,15 @@ func (container *ContainerState) addJVMHeapCommittedSample(sample *ContainerUsag
 	addNewPeak := false
 	if ts.Before(container.WindowEnd) {
 		oldMaxJVMHeapCommitted := container.GetMaxJVMHeapCommittedPeak()
-		if sample.Usage > oldMaxJVMHeapCommitted {
+		if oldMaxJVMHeapCommitted != 0 && sample.Usage > oldMaxJVMHeapCommitted {
 			// Remove the old peak.
-			if oldMaxJVMHeapCommitted != 0 {
-				oldPeak := ContainerUsageSample{
-					MeasureStart: container.WindowEnd,
-					Usage:        oldMaxJVMHeapCommitted,
-					Request:      sample.Request,
-					Resource:     ResourceJVMHeapCommitted,
-				}
-				container.aggregator.SubtractSample(&oldPeak)
+			oldPeak := ContainerUsageSample{
+				MeasureStart: container.WindowEnd,
+				Usage:        oldMaxJVMHeapCommitted,
+				Request:      sample.Request,
+				Resource:     ResourceJVMHeapCommitted,
 			}
+			container.aggregator.SubtractSample(&oldPeak)
 			addNewPeak = true
 		}
 	} else {

--- a/vertical-pod-autoscaler/pkg/recommender/model/container.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/container.go
@@ -168,7 +168,7 @@ func (container *ContainerState) addMemorySample(sample *ContainerUsageSample, i
 	addNewPeak := false
 	if ts.Before(container.WindowEnd) {
 		oldMaxMem := container.GetMaxMemoryPeak()
-		if oldMaxMem != 0 && sample.Usage > oldMaxMem {
+		if sample.Usage > oldMaxMem {
 			// Remove the old peak.
 			if oldMaxMem != 0 {
 				oldPeak := ContainerUsageSample{

--- a/vertical-pod-autoscaler/pkg/recommender/model/container.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/container.go
@@ -220,7 +220,6 @@ func (container *ContainerState) addRSSSample(sample *ContainerUsageSample, isOO
 	}
 	container.lastRSSSampleStart = ts
 	if container.RSSWindowEnd.IsZero() { // This is the first sample.
-		klog.Infof("first RSS sample")
 		container.RSSWindowEnd = ts
 	}
 
@@ -231,9 +230,7 @@ func (container *ContainerState) addRSSSample(sample *ContainerUsageSample, isOO
 	addNewPeak := false
 	if ts.Before(container.RSSWindowEnd) {
 		oldMaxRss := container.GetMaxRSSPeak()
-		klog.Infof("sample was taken in the same aggregation interval")
 		if oldMaxRss != 0 && sample.Usage > oldMaxRss {
-			klog.Infof("sample is larger than the current peak")
 			// Remove the old peak.
 			oldPeak := ContainerUsageSample{
 				MeasureStart: container.RSSWindowEnd,
@@ -245,7 +242,6 @@ func (container *ContainerState) addRSSSample(sample *ContainerUsageSample, isOO
 			addNewPeak = true
 		}
 	} else {
-		klog.Infof("sample taken in a new aggregation interval")
 		// TODO: Use a separate aggregation interval for RSS.
 		rssAggregationInterval := GetAggregationsConfig().MemoryAggregationInterval
 		shift := ts.Sub(container.RSSWindowEnd).Truncate(rssAggregationInterval) + rssAggregationInterval
@@ -255,7 +251,6 @@ func (container *ContainerState) addRSSSample(sample *ContainerUsageSample, isOO
 	}
 	// TODO: Observe quality metrics once OOM is considered.
 	if addNewPeak {
-		klog.Infof("Adding new peak for RSS +%v", sample.Usage)
 		newPeak := ContainerUsageSample{
 			MeasureStart: container.RSSWindowEnd,
 			Usage:        sample.Usage,

--- a/vertical-pod-autoscaler/pkg/recommender/model/container.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/container.go
@@ -53,6 +53,10 @@ type ContainerState struct {
 	memoryPeak ResourceAmount
 	// Max memory usage estimated from an OOM event in the current aggregation interval.
 	oomPeak ResourceAmount
+	// Max RSS usage observed in the current aggregation interval.
+	rssPeak ResourceAmount
+	// Max committed JVM Heap usage observed in the current aggregation interval.
+	jvmHeapCommittedPeak ResourceAmount
 	// End time of the current memory aggregation interval (not inclusive).
 	WindowEnd time.Time
 	// Start of the latest memory usage sample that was aggregated.
@@ -93,28 +97,7 @@ func (container *ContainerState) addCPUSample(sample *ContainerUsageSample) bool
 	return true
 }
 
-func (container *ContainerState) addRSSSample(sample *ContainerUsageSample) bool {
-	if !sample.isValid(ResourceRSS) || !sample.MeasureStart.After(container.lastRSSSampleStart) {
-		return false // Discard invalid, duplicate or out-of-order samples.
-	}
-	// TODO: Observe quality metrics once RSS aggregation moves away from the naive max to by histogram.
-	// container.observeQualityMetrics(sample.Usage, false, corev1.ResourceName(ResourceRSS))
-	container.aggregator.AddSample(sample)
-	container.lastRSSSampleStart = sample.MeasureStart
-	return true
-}
-
-func (container *ContainerState) addJVMHeapCommittedSample(sample *ContainerUsageSample) bool {
-	if !sample.isValid(ResourceJVMHeapCommitted) || !sample.MeasureStart.After(container.lastJVMHeapCommittedSampleStart) {
-		return false // Discard invalid, duplicate or out-of-order samples.
-	}
-	// TODO: Observe quality metrics once JVM Heap aggregation moves away from the naive max to by histogram.
-	// container.observeQualityMetrics(sample.Usage, false, corev1.ResourceName(ResourceJVMHeapCommitted))
-	container.aggregator.AddSample(sample)
-	container.lastJVMHeapCommittedSampleStart = sample.MeasureStart
-	return true
-}
-
+// TODO: Add quality metrics for RSS and JVMHeapCommitted.
 func (container *ContainerState) observeQualityMetrics(usage ResourceAmount, isOOM bool, resource corev1.ResourceName) {
 	if !container.aggregator.NeedsRecommendation() {
 		return
@@ -154,6 +137,18 @@ func (container *ContainerState) GetMaxMemoryPeak() ResourceAmount {
 	return ResourceAmountMax(container.memoryPeak, container.oomPeak)
 }
 
+// GetMaxRSSPeak returns maximum RSS usage in the sample, possibly estimated from OOM
+// TODO: Consider OOM in max RSS peak.
+func (container *ContainerState) GetMaxRSSPeak() ResourceAmount {
+	return container.rssPeak
+}
+
+// GetMaxJVMHeapCommittedPeak returns maximum memory usage in the sample, possibly estimated from OOM
+// TODO: Consider OOM in max JVM Heap committed peak.
+func (container *ContainerState) GetMaxJVMHeapCommittedPeak() ResourceAmount {
+	return container.jvmHeapCommittedPeak
+}
+
 func (container *ContainerState) addMemorySample(sample *ContainerUsageSample, isOOM bool) bool {
 	ts := sample.MeasureStart
 	// We always process OOM samples.
@@ -175,13 +170,15 @@ func (container *ContainerState) addMemorySample(sample *ContainerUsageSample, i
 		oldMaxMem := container.GetMaxMemoryPeak()
 		if oldMaxMem != 0 && sample.Usage > oldMaxMem {
 			// Remove the old peak.
-			oldPeak := ContainerUsageSample{
-				MeasureStart: container.WindowEnd,
-				Usage:        oldMaxMem,
-				Request:      sample.Request,
-				Resource:     ResourceMemory,
+			if oldMaxMem != 0 {
+				oldPeak := ContainerUsageSample{
+					MeasureStart: container.WindowEnd,
+					Usage:        oldMaxMem,
+					Request:      sample.Request,
+					Resource:     ResourceMemory,
+				}
+				container.aggregator.SubtractSample(&oldPeak)
 			}
-			container.aggregator.SubtractSample(&oldPeak)
 			addNewPeak = true
 		}
 	} else {
@@ -207,6 +204,115 @@ func (container *ContainerState) addMemorySample(sample *ContainerUsageSample, i
 		} else {
 			container.memoryPeak = sample.Usage
 		}
+	}
+	return true
+}
+
+// TODO: Handle OOM samples.
+func (container *ContainerState) addRSSSample(sample *ContainerUsageSample, isOOM bool) bool {
+	ts := sample.MeasureStart
+	if !sample.isValid(ResourceRSS) || ts.Before(container.lastRSSSampleStart) {
+		return false // Discard invalid or outdated samples.
+	}
+	container.lastRSSSampleStart = ts
+	if container.WindowEnd.IsZero() { // This is the first sample.
+		container.WindowEnd = ts
+	}
+
+	// Each container aggregates one peak per aggregation interval. If the timestamp of the
+	// current sample is earlier than the end of the current interval (WindowEnd) and is larger
+	// than the current peak, the peak is updated in the aggregation by subtracting the old value
+	// and adding the new value.
+	addNewPeak := false
+	if ts.Before(container.WindowEnd) {
+		oldMaxRss := container.GetMaxRSSPeak()
+		// ok since windowend is not zero because this is not the first sample
+		// we cann use if oldMaxRss != 0 && sample.Usage > oldMaxRss because then we'd never get the first peak
+		// (at least until the next day when the windowend is reset)
+		if sample.Usage > oldMaxRss {
+			// Remove the old peak.
+			if oldMaxRss != 0 {
+				oldPeak := ContainerUsageSample{
+					MeasureStart: container.WindowEnd,
+					Usage:        oldMaxRss,
+					Request:      sample.Request,
+					Resource:     ResourceRSS,
+				}
+				container.aggregator.SubtractSample(&oldPeak)
+			}
+			addNewPeak = true
+		}
+	} else {
+		// TODO: Use a separate aggregation interval for RSS.
+		rssAggregationInterval := GetAggregationsConfig().MemoryAggregationInterval
+		shift := ts.Sub(container.WindowEnd).Truncate(rssAggregationInterval) + rssAggregationInterval
+		container.WindowEnd = container.WindowEnd.Add(shift)
+		container.rssPeak = 0
+		addNewPeak = true
+	}
+	// TODO: Observe quality metrics once OOM is considered.
+	if addNewPeak {
+		klog.Infof("Adding new peak for RSS +%v", sample.Usage)
+		newPeak := ContainerUsageSample{
+			MeasureStart: container.WindowEnd,
+			Usage:        sample.Usage,
+			Request:      sample.Request,
+			Resource:     ResourceRSS,
+		}
+		container.aggregator.AddSample(&newPeak)
+		container.rssPeak = sample.Usage
+	}
+	return true
+}
+
+func (container *ContainerState) addJVMHeapCommittedSample(sample *ContainerUsageSample, isOOM bool) bool {
+	ts := sample.MeasureStart
+	if !sample.isValid(ResourceJVMHeapCommitted) || ts.Before(container.lastJVMHeapCommittedSampleStart) {
+		return false // Discard invalid or outdated samples.
+	}
+	container.lastJVMHeapCommittedSampleStart = ts
+	if container.WindowEnd.IsZero() { // This is the first sample.
+		container.WindowEnd = ts
+	}
+
+	// Each container aggregates one peak per aggregation interval. If the timestamp of the
+	// current sample is earlier than the end of the current interval (WindowEnd) and is larger
+	// than the current peak, the peak is updated in the aggregation by subtracting the old value
+	// and adding the new value.
+	addNewPeak := false
+	if ts.Before(container.WindowEnd) {
+		oldMaxJVMHeapCommitted := container.GetMaxJVMHeapCommittedPeak()
+		if sample.Usage > oldMaxJVMHeapCommitted {
+			// Remove the old peak.
+			if oldMaxJVMHeapCommitted != 0 {
+				oldPeak := ContainerUsageSample{
+					MeasureStart: container.WindowEnd,
+					Usage:        oldMaxJVMHeapCommitted,
+					Request:      sample.Request,
+					Resource:     ResourceJVMHeapCommitted,
+				}
+				container.aggregator.SubtractSample(&oldPeak)
+			}
+			addNewPeak = true
+		}
+	} else {
+		// TODO: Use a separate aggregation interval for committed JVM heap.
+		jvmHeapCommittedAggregationInterval := GetAggregationsConfig().MemoryAggregationInterval
+		shift := ts.Sub(container.WindowEnd).Truncate(jvmHeapCommittedAggregationInterval) + jvmHeapCommittedAggregationInterval
+		container.WindowEnd = container.WindowEnd.Add(shift)
+		container.jvmHeapCommittedPeak = 0
+		addNewPeak = true
+	}
+	// TODO: Observe quality metrics once OOM is considered.
+	if addNewPeak {
+		newPeak := ContainerUsageSample{
+			MeasureStart: container.WindowEnd,
+			Usage:        sample.Usage,
+			Request:      sample.Request,
+			Resource:     ResourceJVMHeapCommitted,
+		}
+		container.aggregator.AddSample(&newPeak)
+		container.jvmHeapCommittedPeak = sample.Usage
 	}
 	return true
 }
@@ -248,9 +354,9 @@ func (container *ContainerState) AddSample(sample *ContainerUsageSample) bool {
 	case ResourceMemory:
 		return container.addMemorySample(sample, false)
 	case ResourceRSS:
-		return container.addRSSSample(sample)
+		return container.addRSSSample(sample, false)
 	case ResourceJVMHeapCommitted:
-		return container.addJVMHeapCommittedSample(sample)
+		return container.addJVMHeapCommittedSample(sample, false)
 	default:
 		return false
 	}

--- a/vertical-pod-autoscaler/pkg/recommender/model/container.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/container.go
@@ -134,7 +134,7 @@ func (container *ContainerState) observeQualityMetrics(usage ResourceAmount, isO
 	case corev1.ResourceMemory:
 		recommendationValue = float64(recommendation.Value())
 	default:
-		klog.Warningf("Unknown resource: %v", resource)
+		// klog.Warningf("Unknown resource: %v", resource)
 		return
 	}
 	metrics_quality.ObserveQualityMetrics(usageValue, recommendationValue, isOOM, resource, updateMode)

--- a/vertical-pod-autoscaler/pkg/recommender/model/container.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/container.go
@@ -226,9 +226,6 @@ func (container *ContainerState) addRSSSample(sample *ContainerUsageSample, isOO
 	addNewPeak := false
 	if ts.Before(container.WindowEnd) {
 		oldMaxRss := container.GetMaxRSSPeak()
-		// ok since windowend is not zero because this is not the first sample
-		// we cann use if oldMaxRss != 0 && sample.Usage > oldMaxRss because then we'd never get the first peak
-		// (at least until the next day when the windowend is reset)
 		if sample.Usage > oldMaxRss {
 			// Remove the old peak.
 			if oldMaxRss != 0 {

--- a/vertical-pod-autoscaler/pkg/recommender/model/container.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/container.go
@@ -214,6 +214,7 @@ func (container *ContainerState) addRSSSample(sample *ContainerUsageSample, isOO
 	}
 	container.lastRSSSampleStart = ts
 	if container.WindowEnd.IsZero() { // This is the first sample.
+		klog.Infof("first RSS sample")
 		container.WindowEnd = ts
 	}
 
@@ -224,7 +225,9 @@ func (container *ContainerState) addRSSSample(sample *ContainerUsageSample, isOO
 	addNewPeak := false
 	if ts.Before(container.WindowEnd) {
 		oldMaxRss := container.GetMaxRSSPeak()
+		klog.Infof("sample was taken in the same aggregation interval")
 		if oldMaxRss != 0 && sample.Usage > oldMaxRss {
+			klog.Infof("sample is larger than the current peak")
 			// Remove the old peak.
 			oldPeak := ContainerUsageSample{
 				MeasureStart: container.WindowEnd,
@@ -236,6 +239,7 @@ func (container *ContainerState) addRSSSample(sample *ContainerUsageSample, isOO
 			addNewPeak = true
 		}
 	} else {
+		klog.Infof("sample taken in a new aggregation interval")
 		// TODO: Use a separate aggregation interval for RSS.
 		rssAggregationInterval := GetAggregationsConfig().MemoryAggregationInterval
 		shift := ts.Sub(container.WindowEnd).Truncate(rssAggregationInterval) + rssAggregationInterval

--- a/vertical-pod-autoscaler/pkg/utils/metrics/quality/quality.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/quality/quality.go
@@ -167,7 +167,7 @@ func observeUsageRecommendationDiff(usage, recommendation float64, isRecommendat
 				strconv.FormatBool(isRecommendationMissing), strconv.FormatBool(isOOM)).Observe(diff)
 		}
 	default:
-		klog.Warningf("Unknown resource: %v", resource)
+		// klog.Warningf("Unknown resource: %v", resource)
 	}
 }
 
@@ -179,7 +179,7 @@ func observeRecommendation(recommendation float64, isOOM bool, resource corev1.R
 	case corev1.ResourceMemory:
 		memoryRecommendations.WithLabelValues(updateModeToString(updateMode), strconv.FormatBool(isOOM)).Observe(recommendation)
 	default:
-		klog.Warningf("Unknown resource: %v", resource)
+		// klog.Warningf("Unknown resource: %v", resource)
 	}
 }
 
@@ -231,7 +231,7 @@ func quantityAsFloat(resource corev1.ResourceName, quantity resource.Quantity) f
 	case corev1.ResourceMemory:
 		return float64(quantity.Value())
 	default:
-		klog.Warningf("Unknown resource: %v", resource)
+		// klog.Warningf("Unknown resource: %v", resource)
 		return 0.0
 	}
 }

--- a/vertical-pod-autoscaler/pkg/utils/metrics/quality/quality.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/quality/quality.go
@@ -25,7 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/utils/metrics"
-	"k8s.io/klog/v2"
+	// "k8s.io/klog/v2"
 
 	"github.com/prometheus/client_golang/prometheus"
 )

--- a/vertical-pod-autoscaler/pkg/utils/metrics/quality/quality.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/quality/quality.go
@@ -204,7 +204,7 @@ func ObserveRecommendationChange(previous, current corev1.ResourceList, updateMo
 	}
 	// This is not really expected thus a warning.
 	if current == nil {
-		klog.Warningf("Cannot compare with current recommendation being nil. VPA mode: %v, size: %v", updateMode, vpaSize)
+		// klog.Warningf("Cannot compare with current recommendation being nil. VPA mode: %v, size: %v", updateMode, vpaSize)
 		return
 	}
 
@@ -217,7 +217,8 @@ func ObserveRecommendationChange(previous, current corev1.ResourceList, updateMo
 			log2 := metrics.GetVpaSizeLog2(vpaSize)
 			relativeRecommendationChange.WithLabelValues(updateModeToString(updateMode), string(resource), strconv.Itoa(log2)).Observe(diff)
 		} else {
-			klog.Warningf("Cannot compare as old recommendation for %v is 0. VPA mode: %v, size: %v", resource, updateMode, vpaSize)
+			continue
+			// klog.Warningf("Cannot compare as old recommendation for %v is 0. VPA mode: %v, size: %v", resource, updateMode, vpaSize)
 		}
 	}
 }


### PR DESCRIPTION
Replaces the naive `max` recommendation implementations for RSS (https://github.com/jodzga/autoscaler/pull/8) and committed JVM heap (https://github.com/jodzga/autoscaler/pull/9) with the same histogram-based recommendation strategy as the native `memory` recommendation. Essentially, every aggregation interval, we will collect the 1 peak value and add it to the histogram.

Note that we ignore OOMKills and use the same opts as memory (e.g. aggregation interval, count, and percentile) for now.