### PR TITLE
Leekathy/histogram checkpoint 1.0

### DIFF
--- a/vertical-pod-autoscaler/README.md
+++ b/vertical-pod-autoscaler/README.md
@@ -55,6 +55,7 @@ The current default version is Vertical Pod Autoscaler 0.14.0
 
 | VPA version     | Kubernetes version |
 |-----------------|--------------------|
+| 1.0             | 1.25+              |
 | 0.14            | 1.25+              |
 | 0.13            | 1.25+              |
 | 0.12            | 1.25+              |

--- a/vertical-pod-autoscaler/deploy/admission-controller-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/admission-controller-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
         - name: admission-controller
-          image: registry.k8s.io/autoscaling/vpa-admission-controller:0.14.0
+          image: registry.k8s.io/autoscaling/vpa-admission-controller:1.0.0
           imagePullPolicy: Always
           env:
             - name: NAMESPACE

--- a/vertical-pod-autoscaler/deploy/recommender-deployment-high.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment-high.yaml
@@ -26,7 +26,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
       - name: recommender
-        image: registry.k8s.io/autoscaling/vpa-recommender:0.14.0
+        image: registry.k8s.io/autoscaling/vpa-recommender:1.0.0
         imagePullPolicy: Always
         args:
           - --recommender-name=performance

--- a/vertical-pod-autoscaler/deploy/recommender-deployment-low.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment-low.yaml
@@ -26,7 +26,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
       - name: recommender
-        image: registry.k8s.io/autoscaling/vpa-recommender:0.14.0
+        image: registry.k8s.io/autoscaling/vpa-recommender:1.0.0
         imagePullPolicy: Always
         args:
           - --recommender-name=frugal

--- a/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/recommender-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
       - name: recommender
-        image: registry.k8s.io/autoscaling/vpa-recommender:0.14.0
+        image: registry.k8s.io/autoscaling/vpa-recommender:1.0.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/vertical-pod-autoscaler/deploy/updater-deployment.yaml
+++ b/vertical-pod-autoscaler/deploy/updater-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         runAsUser: 65534 # nobody
       containers:
         - name: updater
-          image: registry.k8s.io/autoscaling/vpa-updater:0.14.0
+          image: registry.k8s.io/autoscaling/vpa-updater:1.0.0
           imagePullPolicy: Always
           env:
             - name: NAMESPACE

--- a/vertical-pod-autoscaler/hack/vpa-process-yaml.sh
+++ b/vertical-pod-autoscaler/hack/vpa-process-yaml.sh
@@ -32,7 +32,7 @@ if [ $# -eq 0 ]; then
 fi
 
 DEFAULT_REGISTRY="registry.k8s.io/autoscaling"
-DEFAULT_TAG="0.14.0"
+DEFAULT_TAG="1.0.0"
 
 REGISTRY_TO_APPLY=${REGISTRY-$DEFAULT_REGISTRY}
 TAG_TO_APPLY=${TAG-$DEFAULT_TAG}

--- a/vertical-pod-autoscaler/hack/vpa-process-yamls.sh
+++ b/vertical-pod-autoscaler/hack/vpa-process-yamls.sh
@@ -40,17 +40,16 @@ if [ $# -gt 2 ]; then
 fi
 
 ACTION=$1
-COMPONENTS="vpa-v1-crd-gen vpa-rbac updater-deployment recommender-deployment admission-controller-deployment recommender-externalmetrics-deployment"
-TEST_COMPONENTS=(recommender-externalmetrics-deployment)
+COMPONENTS="vpa-v1-crd-gen vpa-rbac updater-deployment recommender-deployment admission-controller-deployment"
 
 function script_path {
   # Regular components have deployment yaml files under /deploy/.  But some components only have
-  # test deployment yaml files that are under hack/e2e.  If $1 is one of ${TEST_COMPONENTS}, use
-  # the hack/e2e subdir instead of deploy.
-  if printf '%s\0' "${TEST_COMPONENTS[@]}" | grep -Fqxz -- $1; then
-    echo "${SCRIPT_ROOT}/hack/e2e/${1}.yaml"
-  else
+  # test deployment yaml files that are under hack/e2e. Check the main deploy directory before
+  # using the e2e subdirectory.
+  if test -f "${SCRIPT_ROOT}/deploy/${1}.yaml"; then
     echo "${SCRIPT_ROOT}/deploy/${1}.yaml"
+  else
+    echo "${SCRIPT_ROOT}/hack/e2e/${1}.yaml"
   fi
 }
 

--- a/vertical-pod-autoscaler/pkg/admission-controller/gencerts.sh
+++ b/vertical-pod-autoscaler/pkg/admission-controller/gencerts.sh
@@ -51,7 +51,7 @@ set -o errexit
 # Create a server certificate
 openssl genrsa -out ${TMP_DIR}/serverKey.pem 2048
 # Note the CN is the DNS name of the service of the webhook.
-openssl req -new -key ${TMP_DIR}/serverKey.pem -out ${TMP_DIR}/server.csr -subj "/CN=vpa-webhook.kube-system.svc" -config ${TMP_DIR}/server.conf -addext "subjectAltName = DNS:vpa-webhook.kube-system.svc"
+openssl req -new -key ${TMP_DIR}/serverKey.pem -out ${TMP_DIR}/server.csr -subj "/CN=vpa-webhook.kube-system.svc" -config ${TMP_DIR}/server.conf
 openssl x509 -req -in ${TMP_DIR}/server.csr -CA ${TMP_DIR}/caCert.pem -CAkey ${TMP_DIR}/caKey.pem -CAcreateserial -out ${TMP_DIR}/serverCert.pem -days 100000 -extensions SAN -extensions v3_req -extfile ${TMP_DIR}/server.conf
 
 echo "Uploading certs to the cluster."

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
@@ -396,6 +396,12 @@ type VerticalPodAutoscalerCheckpointStatus struct {
 	// Checkpoint of histogram for consumption of memory.
 	MemoryHistogram HistogramCheckpoint `json:"memoryHistogram,omitempty" protobuf:"bytes,4,rep,name=memoryHistogram"`
 
+	// Checkpoint of histogram for consumption of RSS.
+	RSSHistogram HistogramCheckpoint `json:"rssHistogram,omitempty" protobuf:"bytes,5,rep,name=rssHistogram"`
+
+	// Checkpoint of histogram for consumption of committed JVM heap.
+	JVMHeapCommittedHistogram HistogramCheckpoint `json:"jvmHeapCommittedHistogram,omitempty" protobuf:"bytes,6,rep,name=jvmHeapCommittedHistogram"`
+
 	// Timestamp of the fist sample from the histograms.
 	// +nullable
 	FirstSampleStart metav1.Time `json:"firstSampleStart,omitempty" protobuf:"bytes,5,opt,name=firstSampleStart"`

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/zz_generated.deepcopy.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/zz_generated.deepcopy.go
@@ -327,6 +327,8 @@ func (in *VerticalPodAutoscalerCheckpointStatus) DeepCopyInto(out *VerticalPodAu
 	in.LastUpdateTime.DeepCopyInto(&out.LastUpdateTime)
 	in.CPUHistogram.DeepCopyInto(&out.CPUHistogram)
 	in.MemoryHistogram.DeepCopyInto(&out.MemoryHistogram)
+	in.RSSHistogram.DeepCopyInto(&out.RSSHistogram)
+	in.JVMHeapCommittedHistogram.DeepCopyInto(&out.JVMHeapCommittedHistogram)
 	in.FirstSampleStart.DeepCopyInto(&out.FirstSampleStart)
 	in.LastSampleStart.DeepCopyInto(&out.LastSampleStart)
 	return

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/zz_generated.deepcopy.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/zz_generated.deepcopy.go
@@ -328,7 +328,7 @@ func (in *VerticalPodAutoscalerCheckpointStatus) DeepCopyInto(out *VerticalPodAu
 	in.CPUHistogram.DeepCopyInto(&out.CPUHistogram)
 	in.MemoryHistogram.DeepCopyInto(&out.MemoryHistogram)
 	in.RSSHistogram.DeepCopyInto(&out.RSSHistogram)
-	in.jvmHeapCommittedHistogram.DeepCopyInto(&out.jvmHeapCommittedHistogram)
+	in.JVMHeapCommittedHistogram.DeepCopyInto(&out.JVMHeapCommittedHistogram)
 	in.FirstSampleStart.DeepCopyInto(&out.FirstSampleStart)
 	in.LastSampleStart.DeepCopyInto(&out.LastSampleStart)
 	return

--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/zz_generated.deepcopy.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/zz_generated.deepcopy.go
@@ -327,6 +327,8 @@ func (in *VerticalPodAutoscalerCheckpointStatus) DeepCopyInto(out *VerticalPodAu
 	in.LastUpdateTime.DeepCopyInto(&out.LastUpdateTime)
 	in.CPUHistogram.DeepCopyInto(&out.CPUHistogram)
 	in.MemoryHistogram.DeepCopyInto(&out.MemoryHistogram)
+	in.RSSHistogram.DeepCopyInto(&out.RSSHistogram)
+	in.jvmHeapCommittedHistogram.DeepCopyInto(&out.jvmHeapCommittedHistogram)
 	in.FirstSampleStart.DeepCopyInto(&out.FirstSampleStart)
 	in.LastSampleStart.DeepCopyInto(&out.LastSampleStart)
 	return

--- a/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
+++ b/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
@@ -144,7 +144,13 @@ func buildAggregateContainerStateMap(vpa *model.Vpa, cluster *model.ClusterState
 }
 
 func subtractCurrentContainerMemoryPeak(a *model.AggregateContainerState, container *model.ContainerState, now time.Time) {
-	if now.Before(container.WindowEnd) {
-		a.AggregateMemoryPeaks.SubtractSample(model.BytesFromMemoryAmount(container.GetMaxMemoryPeak()), 1.0, container.WindowEnd)
+	if now.Before(container.MemoryWindowEnd) {
+		a.AggregateMemoryPeaks.SubtractSample(model.BytesFromMemoryAmount(container.GetMaxMemoryPeak()), 1.0, container.MemoryWindowEnd)
+	}
+	if now.Before(container.RSSWindowEnd) {
+		a.AggregateRSSPeaks.SubtractSample(model.BytesFromMemoryAmount(container.GetMaxRSSPeak()), 1.0, container.RSSWindowEnd)
+	}
+	if now.Before(container.JVMHeapCommittedWindowEnd) {
+		a.AggregateJVMHeapCommittedPeaks.SubtractSample(model.BytesFromMemoryAmount(container.GetMaxJVMHeapCommittedPeak()), 1.0, container.JVMHeapCommittedWindowEnd)
 	}
 }

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client.go
@@ -114,13 +114,13 @@ func calculateUsage(containerUsage k8sapiv1.ResourceList) model.Resources {
 	rssQuantity := containerUsage[k8sapiv1.ResourceName(model.ResourceRSS)]
 	rssBytes := rssQuantity.Value()
 
-	jvmHeapQuantity := containerUsage[k8sapiv1.ResourceName(model.ResourceJVMHeap)]
-	jvmHeapBytes := jvmHeapQuantity.Value()
+	jvmHeapCommittedQuantity := containerUsage[k8sapiv1.ResourceName(model.ResourceJVMHeapCommitted)]
+	jvmHeapCommittedBytes := jvmHeapCommittedQuantity.Value()
 
 	return model.Resources{
-		model.ResourceCPU:     model.ResourceAmount(cpuMillicores),
-		model.ResourceMemory:  model.ResourceAmount(memoryBytes),
-		model.ResourceRSS:     model.ResourceAmount(rssBytes),
-		model.ResourceJVMHeap: model.ResourceAmount(jvmHeapBytes),
+		model.ResourceCPU:              model.ResourceAmount(cpuMillicores),
+		model.ResourceMemory:           model.ResourceAmount(memoryBytes),
+		model.ResourceRSS:              model.ResourceAmount(rssBytes),
+		model.ResourceJVMHeapCommitted: model.ResourceAmount(jvmHeapCommittedBytes),
 	}
 }

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client.go
@@ -118,9 +118,9 @@ func calculateUsage(containerUsage k8sapiv1.ResourceList) model.Resources {
 	jvmHeapCommittedBytes := jvmHeapCommittedQuantity.Value()
 
 	return model.Resources{
-		model.ResourceCPU:     model.ResourceAmount(cpuMillicores),
-		model.ResourceMemory:  model.ResourceAmount(memoryBytes),
-		model.ResourceRSS:     model.ResourceAmount(rssBytes),
+		model.ResourceCPU:              model.ResourceAmount(cpuMillicores),
+		model.ResourceMemory:           model.ResourceAmount(memoryBytes),
+		model.ResourceRSS:              model.ResourceAmount(rssBytes),
 		model.ResourceJVMHeapCommitted: model.ResourceAmount(jvmHeapCommittedBytes),
 	}
 }

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client.go
@@ -111,8 +111,12 @@ func calculateUsage(containerUsage k8sapiv1.ResourceList) model.Resources {
 	memoryQuantity := containerUsage[k8sapiv1.ResourceMemory]
 	memoryBytes := memoryQuantity.Value()
 
+	rssQuantity := containerUsage[k8sapiv1.ResourceName(model.ResourceRSS)]
+	rssBytes := rssQuantity.Value()
+
 	return model.Resources{
 		model.ResourceCPU:    model.ResourceAmount(cpuMillicores),
 		model.ResourceMemory: model.ResourceAmount(memoryBytes),
+		model.ResourceRSS:    model.ResourceAmount(rssBytes),
 	}
 }

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client.go
@@ -114,9 +114,13 @@ func calculateUsage(containerUsage k8sapiv1.ResourceList) model.Resources {
 	rssQuantity := containerUsage[k8sapiv1.ResourceName(model.ResourceRSS)]
 	rssBytes := rssQuantity.Value()
 
+	jvmHeapQuantity := containerUsage[k8sapiv1.ResourceName(model.ResourceJVMHeap)]
+	jvmHeapBytes := jvmHeapQuantity.Value()
+
 	return model.Resources{
-		model.ResourceCPU:    model.ResourceAmount(cpuMillicores),
-		model.ResourceMemory: model.ResourceAmount(memoryBytes),
-		model.ResourceRSS:    model.ResourceAmount(rssBytes),
+		model.ResourceCPU:     model.ResourceAmount(cpuMillicores),
+		model.ResourceMemory:  model.ResourceAmount(memoryBytes),
+		model.ResourceRSS:     model.ResourceAmount(rssBytes),
+		model.ResourceJVMHeap: model.ResourceAmount(jvmHeapBytes),
 	}
 }

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client.go
@@ -114,13 +114,13 @@ func calculateUsage(containerUsage k8sapiv1.ResourceList) model.Resources {
 	rssQuantity := containerUsage[k8sapiv1.ResourceName(model.ResourceRSS)]
 	rssBytes := rssQuantity.Value()
 
-	jvmHeapQuantity := containerUsage[k8sapiv1.ResourceName(model.ResourceJVMHeap)]
-	jvmHeapBytes := jvmHeapQuantity.Value()
+	jvmHeapCommittedQuantity := containerUsage[k8sapiv1.ResourceName(model.ResourceJVMHeapCommitted)]
+	jvmHeapCommittedBytes := jvmHeapCommittedQuantity.Value()
 
 	return model.Resources{
 		model.ResourceCPU:     model.ResourceAmount(cpuMillicores),
 		model.ResourceMemory:  model.ResourceAmount(memoryBytes),
 		model.ResourceRSS:     model.ResourceAmount(rssBytes),
-		model.ResourceJVMHeap: model.ResourceAmount(jvmHeapBytes),
+		model.ResourceJVMHeapCommitted: model.ResourceAmount(jvmHeapCommittedBytes),
 	}
 }

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client_test_util.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client_test_util.go
@@ -74,9 +74,9 @@ func (tc *metricsClientTestCase) newContainerMetricsSnapshot(id model.ContainerI
 		SnapshotTime:   tc.snapshotTimestamp,
 		SnapshotWindow: tc.snapshotWindow,
 		Usage: model.Resources{
-			model.ResourceCPU:     model.ResourceAmount(cpuUsage),
-			model.ResourceMemory:  model.ResourceAmount(memUsage),
-			model.ResourceRSS:     0,
+			model.ResourceCPU:              model.ResourceAmount(cpuUsage),
+			model.ResourceMemory:           model.ResourceAmount(memUsage),
+			model.ResourceRSS:              0,
 			model.ResourceJVMHeapCommitted: 0,
 		},
 	}
@@ -135,9 +135,9 @@ func calculateResourceList(usage model.Resources) k8sapiv1.ResourceList {
 	jvmHeapCommittedQuantityString := jvmHeapCommittedBytes.String()
 
 	resourceMap := map[k8sapiv1.ResourceName]resource.Quantity{
-		k8sapiv1.ResourceCPU:                         resource.MustParse(cpuQuantityString),
-		k8sapiv1.ResourceMemory:                      resource.MustParse(memoryQuantityString),
-		k8sapiv1.ResourceName(model.ResourceRSS):     resource.MustParse(rssQuantityString),
+		k8sapiv1.ResourceCPU:                                  resource.MustParse(cpuQuantityString),
+		k8sapiv1.ResourceMemory:                               resource.MustParse(memoryQuantityString),
+		k8sapiv1.ResourceName(model.ResourceRSS):              resource.MustParse(rssQuantityString),
 		k8sapiv1.ResourceName(model.ResourceJVMHeapCommitted): resource.MustParse(jvmHeapCommittedQuantityString),
 	}
 	return k8sapiv1.ResourceList(resourceMap)

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client_test_util.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client_test_util.go
@@ -76,6 +76,7 @@ func (tc *metricsClientTestCase) newContainerMetricsSnapshot(id model.ContainerI
 		Usage: model.Resources{
 			model.ResourceCPU:    model.ResourceAmount(cpuUsage),
 			model.ResourceMemory: model.ResourceAmount(memUsage),
+			model.ResourceRSS:    0,
 		},
 	}
 }
@@ -126,9 +127,13 @@ func calculateResourceList(usage model.Resources) k8sapiv1.ResourceList {
 	memoryBytes := big.NewInt(int64(usage[model.ResourceMemory]))
 	memoryQuantityString := memoryBytes.String()
 
+	rssBytes := big.NewInt(int64(usage[model.ResourceRSS]))
+	rssQuantityString := rssBytes.String()
+
 	resourceMap := map[k8sapiv1.ResourceName]resource.Quantity{
-		k8sapiv1.ResourceCPU:    resource.MustParse(cpuQuantityString),
-		k8sapiv1.ResourceMemory: resource.MustParse(memoryQuantityString),
+		k8sapiv1.ResourceCPU:                     resource.MustParse(cpuQuantityString),
+		k8sapiv1.ResourceMemory:                  resource.MustParse(memoryQuantityString),
+		k8sapiv1.ResourceName(model.ResourceRSS): resource.MustParse(rssQuantityString),
 	}
 	return k8sapiv1.ResourceList(resourceMap)
 }

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client_test_util.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client_test_util.go
@@ -85,7 +85,7 @@ func (tc *metricsClientTestCase) createFakeMetricsClient() MetricsClient {
 	fakeMetricsGetter.AddReactor("list", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
 		return true, tc.getFakePodMetricsList(), nil
 	})
-	return NewMetricsClient(NewPodMetricsesSource(fakeMetricsGetter.MetricsV1beta1()), "", "fake")
+	return NewMetricsClient(NewPodMetricsesSource(fakeMetricsGetter.MetricsV1beta1(), ""), "", "fake")
 }
 
 func (tc *metricsClientTestCase) getFakePodMetricsList() *metricsapi.PodMetricsList {

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client_test_util.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client_test_util.go
@@ -74,9 +74,10 @@ func (tc *metricsClientTestCase) newContainerMetricsSnapshot(id model.ContainerI
 		SnapshotTime:   tc.snapshotTimestamp,
 		SnapshotWindow: tc.snapshotWindow,
 		Usage: model.Resources{
-			model.ResourceCPU:    model.ResourceAmount(cpuUsage),
-			model.ResourceMemory: model.ResourceAmount(memUsage),
-			model.ResourceRSS:    0,
+			model.ResourceCPU:     model.ResourceAmount(cpuUsage),
+			model.ResourceMemory:  model.ResourceAmount(memUsage),
+			model.ResourceRSS:     0,
+			model.ResourceJVMHeap: 0,
 		},
 	}
 }
@@ -130,10 +131,14 @@ func calculateResourceList(usage model.Resources) k8sapiv1.ResourceList {
 	rssBytes := big.NewInt(int64(usage[model.ResourceRSS]))
 	rssQuantityString := rssBytes.String()
 
+	jvmHeapBytes := big.NewInt(int64(usage[model.ResourceJVMHeap]))
+	jvmHeapQuantityString := jvmHeapBytes.String()
+
 	resourceMap := map[k8sapiv1.ResourceName]resource.Quantity{
-		k8sapiv1.ResourceCPU:                     resource.MustParse(cpuQuantityString),
-		k8sapiv1.ResourceMemory:                  resource.MustParse(memoryQuantityString),
-		k8sapiv1.ResourceName(model.ResourceRSS): resource.MustParse(rssQuantityString),
+		k8sapiv1.ResourceCPU:                         resource.MustParse(cpuQuantityString),
+		k8sapiv1.ResourceMemory:                      resource.MustParse(memoryQuantityString),
+		k8sapiv1.ResourceName(model.ResourceRSS):     resource.MustParse(rssQuantityString),
+		k8sapiv1.ResourceName(model.ResourceJVMHeap): resource.MustParse(jvmHeapQuantityString),
 	}
 	return k8sapiv1.ResourceList(resourceMap)
 }

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client_test_util.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client_test_util.go
@@ -76,6 +76,7 @@ func (tc *metricsClientTestCase) newContainerMetricsSnapshot(id model.ContainerI
 		Usage: model.Resources{
 			model.ResourceCPU:    model.ResourceAmount(cpuUsage),
 			model.ResourceMemory: model.ResourceAmount(memUsage),
+			model.ResourceRSS:    0,
 		},
 	}
 }
@@ -85,7 +86,7 @@ func (tc *metricsClientTestCase) createFakeMetricsClient() MetricsClient {
 	fakeMetricsGetter.AddReactor("list", "pods", func(action core.Action) (handled bool, ret runtime.Object, err error) {
 		return true, tc.getFakePodMetricsList(), nil
 	})
-	return NewMetricsClient(NewPodMetricsesSource(fakeMetricsGetter.MetricsV1beta1()), "", "fake")
+	return NewMetricsClient(NewPodMetricsesSource(fakeMetricsGetter.MetricsV1beta1(), ""), "", "fake")
 }
 
 func (tc *metricsClientTestCase) getFakePodMetricsList() *metricsapi.PodMetricsList {
@@ -126,9 +127,13 @@ func calculateResourceList(usage model.Resources) k8sapiv1.ResourceList {
 	memoryBytes := big.NewInt(int64(usage[model.ResourceMemory]))
 	memoryQuantityString := memoryBytes.String()
 
+	rssBytes := big.NewInt(int64(usage[model.ResourceRSS]))
+	rssQuantityString := rssBytes.String()
+
 	resourceMap := map[k8sapiv1.ResourceName]resource.Quantity{
-		k8sapiv1.ResourceCPU:    resource.MustParse(cpuQuantityString),
-		k8sapiv1.ResourceMemory: resource.MustParse(memoryQuantityString),
+		k8sapiv1.ResourceCPU:                     resource.MustParse(cpuQuantityString),
+		k8sapiv1.ResourceMemory:                  resource.MustParse(memoryQuantityString),
+		k8sapiv1.ResourceName(model.ResourceRSS): resource.MustParse(rssQuantityString),
 	}
 	return k8sapiv1.ResourceList(resourceMap)
 }

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client_test_util.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client_test_util.go
@@ -74,10 +74,10 @@ func (tc *metricsClientTestCase) newContainerMetricsSnapshot(id model.ContainerI
 		SnapshotTime:   tc.snapshotTimestamp,
 		SnapshotWindow: tc.snapshotWindow,
 		Usage: model.Resources{
-			model.ResourceCPU:     model.ResourceAmount(cpuUsage),
-			model.ResourceMemory:  model.ResourceAmount(memUsage),
-			model.ResourceRSS:     0,
-			model.ResourceJVMHeap: 0,
+			model.ResourceCPU:              model.ResourceAmount(cpuUsage),
+			model.ResourceMemory:           model.ResourceAmount(memUsage),
+			model.ResourceRSS:              0,
+			model.ResourceJVMHeapCommitted: 0,
 		},
 	}
 }
@@ -131,14 +131,14 @@ func calculateResourceList(usage model.Resources) k8sapiv1.ResourceList {
 	rssBytes := big.NewInt(int64(usage[model.ResourceRSS]))
 	rssQuantityString := rssBytes.String()
 
-	jvmHeapBytes := big.NewInt(int64(usage[model.ResourceJVMHeap]))
-	jvmHeapQuantityString := jvmHeapBytes.String()
+	jvmHeapCommittedBytes := big.NewInt(int64(usage[model.ResourceJVMHeapCommitted]))
+	jvmHeapCommittedQuantityString := jvmHeapCommittedBytes.String()
 
 	resourceMap := map[k8sapiv1.ResourceName]resource.Quantity{
-		k8sapiv1.ResourceCPU:                         resource.MustParse(cpuQuantityString),
-		k8sapiv1.ResourceMemory:                      resource.MustParse(memoryQuantityString),
-		k8sapiv1.ResourceName(model.ResourceRSS):     resource.MustParse(rssQuantityString),
-		k8sapiv1.ResourceName(model.ResourceJVMHeap): resource.MustParse(jvmHeapQuantityString),
+		k8sapiv1.ResourceCPU:                                  resource.MustParse(cpuQuantityString),
+		k8sapiv1.ResourceMemory:                               resource.MustParse(memoryQuantityString),
+		k8sapiv1.ResourceName(model.ResourceRSS):              resource.MustParse(rssQuantityString),
+		k8sapiv1.ResourceName(model.ResourceJVMHeapCommitted): resource.MustParse(jvmHeapCommittedQuantityString),
 	}
 	return k8sapiv1.ResourceList(resourceMap)
 }

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client_test_util.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client_test_util.go
@@ -77,7 +77,7 @@ func (tc *metricsClientTestCase) newContainerMetricsSnapshot(id model.ContainerI
 			model.ResourceCPU:     model.ResourceAmount(cpuUsage),
 			model.ResourceMemory:  model.ResourceAmount(memUsage),
 			model.ResourceRSS:     0,
-			model.ResourceJVMHeap: 0,
+			model.ResourceJVMHeapCommitted: 0,
 		},
 	}
 }
@@ -131,14 +131,14 @@ func calculateResourceList(usage model.Resources) k8sapiv1.ResourceList {
 	rssBytes := big.NewInt(int64(usage[model.ResourceRSS]))
 	rssQuantityString := rssBytes.String()
 
-	jvmHeapBytes := big.NewInt(int64(usage[model.ResourceJVMHeap]))
-	jvmHeapQuantityString := jvmHeapBytes.String()
+	jvmHeapCommittedBytes := big.NewInt(int64(usage[model.ResourceJVMHeapCommitted]))
+	jvmHeapCommittedQuantityString := jvmHeapCommittedBytes.String()
 
 	resourceMap := map[k8sapiv1.ResourceName]resource.Quantity{
 		k8sapiv1.ResourceCPU:                         resource.MustParse(cpuQuantityString),
 		k8sapiv1.ResourceMemory:                      resource.MustParse(memoryQuantityString),
 		k8sapiv1.ResourceName(model.ResourceRSS):     resource.MustParse(rssQuantityString),
-		k8sapiv1.ResourceName(model.ResourceJVMHeap): resource.MustParse(jvmHeapQuantityString),
+		k8sapiv1.ResourceName(model.ResourceJVMHeapCommitted): resource.MustParse(jvmHeapCommittedQuantityString),
 	}
 	return k8sapiv1.ResourceList(resourceMap)
 }

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
@@ -61,7 +61,7 @@ func getRSSQuery(containerName string, podName string, namespace string) string 
 	return fmt.Sprintf("max_over_time(container_memory_rss{container_name='%s', pod_name='%s', namespace='%s'}[5m])", containerName, podName, namespace)
 }
 
-func getJVMHeapQuery(containerName string, podName string, namespace string) string {
+func getJVMHeapCommittedQuery(containerName string, podName string, namespace string) string {
 	return fmt.Sprintf("max_over_time(jmx_Memory_HeapMemoryUsage_committed{kubernetes_container_name='%s', kubernetes_pod_name='%s', kubernetes_namespace='%s'}[5m])", containerName, podName, namespace)
 }
 
@@ -77,8 +77,8 @@ func (s podMetricsSource) withM3CustomMetrics(podMetrics *v1beta1.PodMetricsList
 	for i, pod := range podMetrics.Items {
 		for j, container := range pod.Containers {
 			queries := map[string]k8sapiv1.ResourceName{
-				getRSSQuery(container.Name, pod.Name, pod.Namespace):     k8sapiv1.ResourceName(model.ResourceRSS),
-				getJVMHeapQuery(container.Name, pod.Name, pod.Namespace): k8sapiv1.ResourceName(model.ResourceJVMHeap),
+				getRSSQuery(container.Name, pod.Name, pod.Namespace):              k8sapiv1.ResourceName(model.ResourceRSS),
+				getJVMHeapCommittedQuery(container.Name, pod.Name, pod.Namespace): k8sapiv1.ResourceName(model.ResourceJVMHeapCommitted),
 			}
 			for query, resourceName := range queries {
 				params := url.Values{}

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
@@ -77,7 +77,7 @@ func (s podMetricsSource) withM3CustomMetrics(podMetrics *v1beta1.PodMetricsList
 	for i, pod := range podMetrics.Items {
 		for j, container := range pod.Containers {
 			queries := map[string]k8sapiv1.ResourceName{
-				getRSSQuery(container.Name, pod.Name, pod.Namespace):     k8sapiv1.ResourceName(model.ResourceRSS),
+				getRSSQuery(container.Name, pod.Name, pod.Namespace):              k8sapiv1.ResourceName(model.ResourceRSS),
 				getJVMHeapCommittedQuery(container.Name, pod.Name, pod.Namespace): k8sapiv1.ResourceName(model.ResourceJVMHeapCommitted),
 			}
 			for query, resourceName := range queries {

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
@@ -61,6 +61,10 @@ func getRSSQuery(containerName string, podName string, namespace string) string 
 	return fmt.Sprintf("max_over_time(container_memory_rss{container_name='%s', pod_name='%s', namespace='%s'}[5m])", containerName, podName, namespace)
 }
 
+func getJVMHeapQuery(containerName string, podName string, namespace string) string {
+	return fmt.Sprintf("max_over_time(jmx_Memory_HeapMemoryUsage_committed{kubernetes_container_name='%s', kubernetes_pod_name='%s', kubernetes_namespace='%s'}[5m])", containerName, podName, namespace)
+}
+
 // Augments the PodMetricsList with custom metrics from M3.
 func (s podMetricsSource) withM3CustomMetrics(podMetrics *v1beta1.PodMetricsList) (*v1beta1.PodMetricsList, error) {
 	m3Url, err := url.Parse(s.m3Url)
@@ -73,7 +77,8 @@ func (s podMetricsSource) withM3CustomMetrics(podMetrics *v1beta1.PodMetricsList
 	for i, pod := range podMetrics.Items {
 		for j, container := range pod.Containers {
 			queries := map[string]k8sapiv1.ResourceName{
-				getRSSQuery(container.Name, pod.Name, pod.Namespace): k8sapiv1.ResourceName(model.ResourceRSS),
+				getRSSQuery(container.Name, pod.Name, pod.Namespace):     k8sapiv1.ResourceName(model.ResourceRSS),
+				getJVMHeapQuery(container.Name, pod.Name, pod.Namespace): k8sapiv1.ResourceName(model.ResourceJVMHeap),
 			}
 			for query, resourceName := range queries {
 				params := url.Values{}

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
@@ -61,7 +61,7 @@ func getRSSQuery(containerName string, podName string, namespace string) string 
 	return fmt.Sprintf("max_over_time(container_memory_rss{container_name='%s', pod_name='%s', namespace='%s'}[5m])", containerName, podName, namespace)
 }
 
-func getJVMHeapQuery(containerName string, podName string, namespace string) string {
+func getJVMHeapCommittedQuery(containerName string, podName string, namespace string) string {
 	return fmt.Sprintf("max_over_time(jmx_Memory_HeapMemoryUsage_committed{kubernetes_container_name='%s', kubernetes_pod_name='%s', kubernetes_namespace='%s'}[5m])", containerName, podName, namespace)
 }
 
@@ -78,7 +78,7 @@ func (s podMetricsSource) withM3CustomMetrics(podMetrics *v1beta1.PodMetricsList
 		for j, container := range pod.Containers {
 			queries := map[string]k8sapiv1.ResourceName{
 				getRSSQuery(container.Name, pod.Name, pod.Namespace):     k8sapiv1.ResourceName(model.ResourceRSS),
-				getJVMHeapQuery(container.Name, pod.Name, pod.Namespace): k8sapiv1.ResourceName(model.ResourceJVMHeap),
+				getJVMHeapCommittedQuery(container.Name, pod.Name, pod.Namespace): k8sapiv1.ResourceName(model.ResourceJVMHeapCommitted),
 			}
 			for query, resourceName := range queries {
 				params := url.Values{}

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
@@ -18,7 +18,14 @@ package metrics
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
 	k8sapiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
@@ -39,16 +46,125 @@ type PodMetricsLister interface {
 // podMetricsSource is the metrics-client source of metrics.
 type podMetricsSource struct {
 	metricsGetter resourceclient.PodMetricsesGetter
+	m3Url         string
 }
 
 // NewPodMetricsesSource Returns a Source-wrapper around PodMetricsesGetter.
-func NewPodMetricsesSource(source resourceclient.PodMetricsesGetter) PodMetricsLister {
-	return podMetricsSource{metricsGetter: source}
+func NewPodMetricsesSource(source resourceclient.PodMetricsesGetter, m3Url string) PodMetricsLister {
+	return podMetricsSource{
+		metricsGetter: source,
+		m3Url:         m3Url,
+	}
+}
+
+func getRSSQuery(containerName string, podName string, namespace string) string {
+	return fmt.Sprintf("max_over_time(container_memory_rss{container_name='%s', pod_name='%s', namespace='%s'}[5m])", containerName, podName, namespace)
+}
+
+// Augments the PodMetricsList with custom metrics from M3.
+func (s podMetricsSource) withM3CustomMetrics(podMetrics *v1beta1.PodMetricsList) (*v1beta1.PodMetricsList, error) {
+	m3Url, err := url.Parse(s.m3Url)
+	if err != nil {
+		klog.ErrorS(err, "Failed to parse M3 URL")
+		return nil, err
+	}
+	m3Url.Path += "/api/v1/query"
+
+	for i, pod := range podMetrics.Items {
+		for j, container := range pod.Containers {
+			queries := map[string]k8sapiv1.ResourceName{
+				getRSSQuery(container.Name, pod.Name, pod.Namespace): k8sapiv1.ResourceName(model.ResourceRSS),
+			}
+			for query, resourceName := range queries {
+				params := url.Values{}
+				params.Add("query", query)
+				m3Url.RawQuery = params.Encode()
+
+				resp, err := http.Get(m3Url.String())
+				if err != nil {
+					klog.ErrorS(err, "Failed to query M3", "query", query)
+					continue
+				}
+				if resp.StatusCode != http.StatusOK {
+					klog.ErrorS(err, "Failed to get valid response", "query", query, "status", resp.Status)
+					continue
+				}
+
+				defer resp.Body.Close()
+				body, err := ioutil.ReadAll(resp.Body)
+				if err != nil {
+					klog.ErrorS(err, "Failed to read response body", "query", query)
+					continue
+				}
+
+				var responseBody map[string]interface{}
+				if err := json.Unmarshal(body, &responseBody); err != nil {
+					klog.ErrorS(err, "Failed to unmarshal JSON", "body", string(body))
+					continue
+				}
+				data, ok := (responseBody["data"]).(map[string]interface{})
+				if !ok {
+					klog.Errorf("Failed to get .data from JSON: %+v", responseBody)
+					continue
+				}
+				result, ok := (data["result"]).([]interface{})
+				if !ok {
+					klog.Errorf("Failed to get .data.result from JSON: %+v", responseBody)
+					continue
+				}
+				if len(result) == 0 {
+					klog.Errorf("Failed to get any query results in .data.result: %+v", responseBody)
+					continue
+				}
+				if len(result) > 1 {
+					klog.Errorf("More than one query result in .data.result: %+v", responseBody)
+					// Proceed for now and just use the first result. Will need to fine-tune the query if so.
+				}
+				firstResult, ok := (result[0]).(map[string]interface{})
+				if !ok {
+					klog.Errorf("Failed to get first element from .data.result: %+v", responseBody)
+					continue
+				}
+				value, ok := (firstResult["value"]).([]interface{})
+				if !ok {
+					klog.Errorf("Failed to get .data.result[0].value: %+v", responseBody)
+					continue
+				}
+				resourceValue, ok := (value[1]).(string)
+				if !ok {
+					klog.Errorf("Failed to get .data.result[0].value[1]: %+v", responseBody)
+					continue
+				}
+
+				resourceQuantity, err := resource.ParseQuantity(resourceValue)
+				if err != nil {
+					klog.ErrorS(err, "Failed to parse as resource quantity", "resourceValue", resourceValue)
+					continue
+				}
+
+				podMetrics.Items[i].Containers[j].Usage[resourceName] = resourceQuantity
+				klog.InfoS("Added container usage data from M3", "resource", resourceName, "value", resourceQuantity, "container", container.Name, "pod", pod.Name, "namespace", pod.Namespace)
+			}
+		}
+	}
+
+	return podMetrics, nil
 }
 
 func (s podMetricsSource) List(ctx context.Context, namespace string, opts v1.ListOptions) (*v1beta1.PodMetricsList, error) {
 	podMetricsInterface := s.metricsGetter.PodMetricses(namespace)
-	return podMetricsInterface.List(ctx, opts)
+	podsMetrics, err := podMetricsInterface.List(ctx, opts)
+	if err != nil {
+		klog.ErrorS(err, "Failed to query pod usage metrics from the Metrics API")
+		return nil, err
+	}
+
+	if s.m3Url == "" {
+		klog.Info("No M3 URL provided - skipping custom pod usage metrics")
+		return podsMetrics, nil
+	}
+
+	return s.withM3CustomMetrics(podsMetrics)
 }
 
 // externalMetricsClient is the External Metrics source of metrics.

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
@@ -159,6 +159,11 @@ func (s podMetricsSource) List(ctx context.Context, namespace string, opts v1.Li
 		return nil, err
 	}
 
+	if s.m3Url == "" {
+		klog.Info("No M3 URL provided - skipping custom pod usage metrics")
+		return podsMetrics, nil
+	}
+
 	return s.withM3CustomMetrics(podsMetrics)
 }
 

--- a/vertical-pod-autoscaler/pkg/recommender/logic/estimator.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/estimator.go
@@ -100,8 +100,9 @@ func (e *percentileEstimator) GetResourceEstimation(s *model.AggregateContainerS
 			s.AggregateCPUUsage.Percentile(e.cpuPercentile)),
 		model.ResourceMemory: model.MemoryAmountFromBytes(
 			s.AggregateMemoryPeaks.Percentile(e.memoryPercentile)),
-		// TODO: Take percentile once RSS aggregation moves away from the naive max to by histogram.
-		model.ResourceRSS: model.MemoryAmountFromBytes(s.RSSBytes),
+		// TODO: Take percentile once RSS + JVM Heap aggregation moves away from the naive max to by histogram.
+		model.ResourceRSS:     model.MemoryAmountFromBytes(s.RSSBytes),
+		model.ResourceJVMHeap: model.MemoryAmountFromBytes(s.JVMHeapBytes),
 	}
 }
 

--- a/vertical-pod-autoscaler/pkg/recommender/logic/estimator.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/estimator.go
@@ -101,7 +101,7 @@ func (e *percentileEstimator) GetResourceEstimation(s *model.AggregateContainerS
 		model.ResourceMemory: model.MemoryAmountFromBytes(
 			s.AggregateMemoryPeaks.Percentile(e.memoryPercentile)),
 		// TODO: Take percentile once RSS + JVM Heap aggregation moves away from the naive max to by histogram.
-		model.ResourceRSS:     model.MemoryAmountFromBytes(s.RSSBytes),
+		model.ResourceRSS:              model.MemoryAmountFromBytes(s.RSSBytes),
 		model.ResourceJVMHeapCommitted: model.MemoryAmountFromBytes(s.JVMHeapCommittedBytes),
 	}
 }

--- a/vertical-pod-autoscaler/pkg/recommender/logic/estimator.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/estimator.go
@@ -101,8 +101,8 @@ func (e *percentileEstimator) GetResourceEstimation(s *model.AggregateContainerS
 		model.ResourceMemory: model.MemoryAmountFromBytes(
 			s.AggregateMemoryPeaks.Percentile(e.memoryPercentile)),
 		// TODO: Take percentile once RSS + JVM Heap aggregation moves away from the naive max to by histogram.
-		model.ResourceRSS:     model.MemoryAmountFromBytes(s.RSSBytes),
-		model.ResourceJVMHeap: model.MemoryAmountFromBytes(s.JVMHeapBytes),
+		model.ResourceRSS:              model.MemoryAmountFromBytes(s.RSSBytes),
+		model.ResourceJVMHeapCommitted: model.MemoryAmountFromBytes(s.JVMHeapCommittedBytes),
 	}
 }
 

--- a/vertical-pod-autoscaler/pkg/recommender/logic/estimator.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/estimator.go
@@ -100,9 +100,9 @@ func (e *percentileEstimator) GetResourceEstimation(s *model.AggregateContainerS
 			s.AggregateCPUUsage.Percentile(e.cpuPercentile)),
 		model.ResourceMemory: model.MemoryAmountFromBytes(
 			s.AggregateMemoryPeaks.Percentile(e.memoryPercentile)),
-		// TODO: Take percentile once RSS + JVM Heap aggregation moves away from the naive max to by histogram.
-		model.ResourceRSS:              model.MemoryAmountFromBytes(s.RSSBytes),
-		model.ResourceJVMHeapCommitted: model.MemoryAmountFromBytes(s.JVMHeapCommittedBytes),
+		// TODO: Use individual config for RSS and JVMHeapCommitted.
+		model.ResourceRSS:              model.MemoryAmountFromBytes(s.AggregateRSSPeaks.Percentile(e.memoryPercentile)),
+		model.ResourceJVMHeapCommitted: model.MemoryAmountFromBytes(s.AggregateJVMHeapCommittedPeaks.Percentile(e.memoryPercentile)),
 	}
 }
 

--- a/vertical-pod-autoscaler/pkg/recommender/logic/estimator.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/estimator.go
@@ -102,7 +102,7 @@ func (e *percentileEstimator) GetResourceEstimation(s *model.AggregateContainerS
 			s.AggregateMemoryPeaks.Percentile(e.memoryPercentile)),
 		// TODO: Take percentile once RSS + JVM Heap aggregation moves away from the naive max to by histogram.
 		model.ResourceRSS:     model.MemoryAmountFromBytes(s.RSSBytes),
-		model.ResourceJVMHeap: model.MemoryAmountFromBytes(s.JVMHeapBytes),
+		model.ResourceJVMHeapCommitted: model.MemoryAmountFromBytes(s.JVMHeapCommittedBytes),
 	}
 }
 

--- a/vertical-pod-autoscaler/pkg/recommender/logic/estimator.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/estimator.go
@@ -100,6 +100,8 @@ func (e *percentileEstimator) GetResourceEstimation(s *model.AggregateContainerS
 			s.AggregateCPUUsage.Percentile(e.cpuPercentile)),
 		model.ResourceMemory: model.MemoryAmountFromBytes(
 			s.AggregateMemoryPeaks.Percentile(e.memoryPercentile)),
+		// TODO: Take percentile once RSS aggregation moves away from the naive max to by histogram.
+		model.ResourceRSS: model.MemoryAmountFromBytes(s.RSSBytes),
 	}
 }
 

--- a/vertical-pod-autoscaler/pkg/recommender/logic/estimator_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/estimator_test.go
@@ -54,8 +54,10 @@ func TestPercentileEstimator(t *testing.T) {
 
 	resourceEstimation := estimator.GetResourceEstimation(
 		&model.AggregateContainerState{
-			AggregateCPUUsage:    cpuHistogram,
-			AggregateMemoryPeaks: memoryPeaksHistogram,
+			AggregateCPUUsage:              cpuHistogram,
+			AggregateMemoryPeaks:           memoryPeaksHistogram,
+			AggregateRSSPeaks:              memoryPeaksHistogram,
+			AggregateJVMHeapCommittedPeaks: memoryPeaksHistogram,
 		})
 	maxRelativeError := 0.05 // Allow 5% relative error to account for histogram rounding.
 	assert.InEpsilon(t, 1.0, model.CoresFromCPUAmount(resourceEstimation[model.ResourceCPU]), maxRelativeError)

--- a/vertical-pod-autoscaler/pkg/recommender/logic/recommender.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/recommender.go
@@ -29,7 +29,7 @@ var (
 	podMinCPUMillicores  = flag.Float64("pod-recommendation-min-cpu-millicores", 25, `Minimum CPU recommendation for a pod`)
 	podMinMemoryMb       = flag.Float64("pod-recommendation-min-memory-mb", 0, `Minimum memory recommendation for a pod`)
 	podMinRSSMb          = flag.Float64("pod-recommendation-min-rss-mb", 0, `Minimum RSS recommendation for a pod`)
-	podMinJVMHeapMb      = flag.Float64("pod-recommendation-min-jvmheap-mb", 0, `Minimum JVM Heap recommendation for a pod`)
+	podMinJVMHeapCommittedMb      = flag.Float64("pod-recommendation-min-jvmheapcommitted-mb", 0, `Minimum committed JVM Heap recommendation for a pod`)
 	targetCPUPercentile  = flag.Float64("target-cpu-percentile", 0.9, "CPU usage percentile that will be used as a base for CPU target recommendation. Doesn't affect CPU lower bound, CPU upper bound nor memory recommendations.")
 )
 
@@ -69,7 +69,7 @@ func (r *podResourceRecommender) GetRecommendedPodResources(containerNameToAggre
 		model.ResourceCPU:     model.ScaleResource(model.CPUAmountFromCores(*podMinCPUMillicores*0.001), fraction),
 		model.ResourceMemory:  model.ScaleResource(model.MemoryAmountFromBytes(*podMinMemoryMb*1024*1024), fraction),
 		model.ResourceRSS:     model.ScaleResource(model.MemoryAmountFromBytes(*podMinRSSMb*1024*1024), fraction),
-		model.ResourceJVMHeap: model.ScaleResource(model.MemoryAmountFromBytes(*podMinJVMHeapMb*1024*1024), fraction),
+		model.ResourceJVMHeapCommitted: model.ScaleResource(model.MemoryAmountFromBytes(*podMinJVMHeapCommittedMb*1024*1024), fraction),
 	}
 
 	recommender := &podResourceRecommender{

--- a/vertical-pod-autoscaler/pkg/recommender/logic/recommender.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/recommender.go
@@ -29,6 +29,7 @@ var (
 	podMinCPUMillicores  = flag.Float64("pod-recommendation-min-cpu-millicores", 25, `Minimum CPU recommendation for a pod`)
 	podMinMemoryMb       = flag.Float64("pod-recommendation-min-memory-mb", 250, `Minimum memory recommendation for a pod`)
 	podMinRSSMb          = flag.Float64("pod-recommendation-min-rss-mb", 0, `Minimum RSS recommendation for a pod`)
+	podMinJVMHeapMb      = flag.Float64("pod-recommendation-min-jvmheap-mb", 0, `Minimum JVM Heap recommendation for a pod`)
 	targetCPUPercentile  = flag.Float64("target-cpu-percentile", 0.9, "CPU usage percentile that will be used as a base for CPU target recommendation. Doesn't affect CPU lower bound, CPU upper bound nor memory recommendations.")
 )
 
@@ -65,9 +66,10 @@ func (r *podResourceRecommender) GetRecommendedPodResources(containerNameToAggre
 
 	fraction := 1.0 / float64(len(containerNameToAggregateStateMap))
 	minResources := model.Resources{
-		model.ResourceCPU:    model.ScaleResource(model.CPUAmountFromCores(*podMinCPUMillicores*0.001), fraction),
-		model.ResourceMemory: model.ScaleResource(model.MemoryAmountFromBytes(*podMinMemoryMb*1024*1024), fraction),
-		model.ResourceRSS:    model.ScaleResource(model.MemoryAmountFromBytes(*podMinRSSMb*1024*1024), fraction),
+		model.ResourceCPU:     model.ScaleResource(model.CPUAmountFromCores(*podMinCPUMillicores*0.001), fraction),
+		model.ResourceMemory:  model.ScaleResource(model.MemoryAmountFromBytes(*podMinMemoryMb*1024*1024), fraction),
+		model.ResourceRSS:     model.ScaleResource(model.MemoryAmountFromBytes(*podMinRSSMb*1024*1024), fraction),
+		model.ResourceJVMHeap: model.ScaleResource(model.MemoryAmountFromBytes(*podMinJVMHeapMb*1024*1024), fraction),
 	}
 
 	recommender := &podResourceRecommender{

--- a/vertical-pod-autoscaler/pkg/recommender/logic/recommender.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/recommender.go
@@ -27,7 +27,7 @@ import (
 var (
 	safetyMarginFraction = flag.Float64("recommendation-margin-fraction", 0.15, `Fraction of usage added as the safety margin to the recommended request`)
 	podMinCPUMillicores  = flag.Float64("pod-recommendation-min-cpu-millicores", 25, `Minimum CPU recommendation for a pod`)
-	podMinMemoryMb       = flag.Float64("pod-recommendation-min-memory-mb", 250, `Minimum memory recommendation for a pod`)
+	podMinMemoryMb       = flag.Float64("pod-recommendation-min-memory-mb", 0, `Minimum memory recommendation for a pod`)
 	podMinRSSMb          = flag.Float64("pod-recommendation-min-rss-mb", 0, `Minimum RSS recommendation for a pod`)
 	podMinJVMHeapMb      = flag.Float64("pod-recommendation-min-jvmheap-mb", 0, `Minimum JVM Heap recommendation for a pod`)
 	targetCPUPercentile  = flag.Float64("target-cpu-percentile", 0.9, "CPU usage percentile that will be used as a base for CPU target recommendation. Doesn't affect CPU lower bound, CPU upper bound nor memory recommendations.")

--- a/vertical-pod-autoscaler/pkg/recommender/logic/recommender.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/recommender.go
@@ -28,6 +28,7 @@ var (
 	safetyMarginFraction = flag.Float64("recommendation-margin-fraction", 0.15, `Fraction of usage added as the safety margin to the recommended request`)
 	podMinCPUMillicores  = flag.Float64("pod-recommendation-min-cpu-millicores", 25, `Minimum CPU recommendation for a pod`)
 	podMinMemoryMb       = flag.Float64("pod-recommendation-min-memory-mb", 250, `Minimum memory recommendation for a pod`)
+	podMinRSSMb          = flag.Float64("pod-recommendation-min-rss-mb", 0, `Minimum RSS recommendation for a pod`)
 	targetCPUPercentile  = flag.Float64("target-cpu-percentile", 0.9, "CPU usage percentile that will be used as a base for CPU target recommendation. Doesn't affect CPU lower bound, CPU upper bound nor memory recommendations.")
 )
 
@@ -66,6 +67,7 @@ func (r *podResourceRecommender) GetRecommendedPodResources(containerNameToAggre
 	minResources := model.Resources{
 		model.ResourceCPU:    model.ScaleResource(model.CPUAmountFromCores(*podMinCPUMillicores*0.001), fraction),
 		model.ResourceMemory: model.ScaleResource(model.MemoryAmountFromBytes(*podMinMemoryMb*1024*1024), fraction),
+		model.ResourceRSS:    model.ScaleResource(model.MemoryAmountFromBytes(*podMinRSSMb*1024*1024), fraction),
 	}
 
 	recommender := &podResourceRecommender{

--- a/vertical-pod-autoscaler/pkg/recommender/logic/recommender.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/recommender.go
@@ -25,12 +25,12 @@ import (
 )
 
 var (
-	safetyMarginFraction = flag.Float64("recommendation-margin-fraction", 0.15, `Fraction of usage added as the safety margin to the recommended request`)
-	podMinCPUMillicores  = flag.Float64("pod-recommendation-min-cpu-millicores", 25, `Minimum CPU recommendation for a pod`)
-	podMinMemoryMb       = flag.Float64("pod-recommendation-min-memory-mb", 0, `Minimum memory recommendation for a pod`)
-	podMinRSSMb          = flag.Float64("pod-recommendation-min-rss-mb", 0, `Minimum RSS recommendation for a pod`)
-	podMinJVMHeapCommittedMb      = flag.Float64("pod-recommendation-min-jvmheapcommitted-mb", 0, `Minimum committed JVM Heap recommendation for a pod`)
-	targetCPUPercentile  = flag.Float64("target-cpu-percentile", 0.9, "CPU usage percentile that will be used as a base for CPU target recommendation. Doesn't affect CPU lower bound, CPU upper bound nor memory recommendations.")
+	safetyMarginFraction     = flag.Float64("recommendation-margin-fraction", 0.15, `Fraction of usage added as the safety margin to the recommended request`)
+	podMinCPUMillicores      = flag.Float64("pod-recommendation-min-cpu-millicores", 25, `Minimum CPU recommendation for a pod`)
+	podMinMemoryMb           = flag.Float64("pod-recommendation-min-memory-mb", 0, `Minimum memory recommendation for a pod`)
+	podMinRSSMb              = flag.Float64("pod-recommendation-min-rss-mb", 0, `Minimum RSS recommendation for a pod`)
+	podMinJVMHeapCommittedMb = flag.Float64("pod-recommendation-min-jvmheapcommitted-mb", 0, `Minimum committed JVM Heap recommendation for a pod`)
+	targetCPUPercentile      = flag.Float64("target-cpu-percentile", 0.9, "CPU usage percentile that will be used as a base for CPU target recommendation. Doesn't affect CPU lower bound, CPU upper bound nor memory recommendations.")
 )
 
 // PodResourceRecommender computes resource recommendation for a Vpa object.
@@ -66,9 +66,9 @@ func (r *podResourceRecommender) GetRecommendedPodResources(containerNameToAggre
 
 	fraction := 1.0 / float64(len(containerNameToAggregateStateMap))
 	minResources := model.Resources{
-		model.ResourceCPU:     model.ScaleResource(model.CPUAmountFromCores(*podMinCPUMillicores*0.001), fraction),
-		model.ResourceMemory:  model.ScaleResource(model.MemoryAmountFromBytes(*podMinMemoryMb*1024*1024), fraction),
-		model.ResourceRSS:     model.ScaleResource(model.MemoryAmountFromBytes(*podMinRSSMb*1024*1024), fraction),
+		model.ResourceCPU:              model.ScaleResource(model.CPUAmountFromCores(*podMinCPUMillicores*0.001), fraction),
+		model.ResourceMemory:           model.ScaleResource(model.MemoryAmountFromBytes(*podMinMemoryMb*1024*1024), fraction),
+		model.ResourceRSS:              model.ScaleResource(model.MemoryAmountFromBytes(*podMinRSSMb*1024*1024), fraction),
 		model.ResourceJVMHeapCommitted: model.ScaleResource(model.MemoryAmountFromBytes(*podMinJVMHeapCommittedMb*1024*1024), fraction),
 	}
 

--- a/vertical-pod-autoscaler/pkg/recommender/logic/recommender.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/recommender.go
@@ -25,12 +25,12 @@ import (
 )
 
 var (
-	safetyMarginFraction = flag.Float64("recommendation-margin-fraction", 0.15, `Fraction of usage added as the safety margin to the recommended request`)
-	podMinCPUMillicores  = flag.Float64("pod-recommendation-min-cpu-millicores", 25, `Minimum CPU recommendation for a pod`)
-	podMinMemoryMb       = flag.Float64("pod-recommendation-min-memory-mb", 0, `Minimum memory recommendation for a pod`)
-	podMinRSSMb          = flag.Float64("pod-recommendation-min-rss-mb", 0, `Minimum RSS recommendation for a pod`)
-	podMinJVMHeapMb      = flag.Float64("pod-recommendation-min-jvmheap-mb", 0, `Minimum JVM Heap recommendation for a pod`)
-	targetCPUPercentile  = flag.Float64("target-cpu-percentile", 0.9, "CPU usage percentile that will be used as a base for CPU target recommendation. Doesn't affect CPU lower bound, CPU upper bound nor memory recommendations.")
+	safetyMarginFraction     = flag.Float64("recommendation-margin-fraction", 0.15, `Fraction of usage added as the safety margin to the recommended request`)
+	podMinCPUMillicores      = flag.Float64("pod-recommendation-min-cpu-millicores", 25, `Minimum CPU recommendation for a pod`)
+	podMinMemoryMb           = flag.Float64("pod-recommendation-min-memory-mb", 0, `Minimum memory recommendation for a pod`)
+	podMinRSSMb              = flag.Float64("pod-recommendation-min-rss-mb", 0, `Minimum RSS recommendation for a pod`)
+	podMinJVMHeapCommittedMb = flag.Float64("pod-recommendation-min-jvmheapcommitted-mb", 0, `Minimum committed JVM Heap recommendation for a pod`)
+	targetCPUPercentile      = flag.Float64("target-cpu-percentile", 0.9, "CPU usage percentile that will be used as a base for CPU target recommendation. Doesn't affect CPU lower bound, CPU upper bound nor memory recommendations.")
 )
 
 // PodResourceRecommender computes resource recommendation for a Vpa object.
@@ -66,10 +66,10 @@ func (r *podResourceRecommender) GetRecommendedPodResources(containerNameToAggre
 
 	fraction := 1.0 / float64(len(containerNameToAggregateStateMap))
 	minResources := model.Resources{
-		model.ResourceCPU:     model.ScaleResource(model.CPUAmountFromCores(*podMinCPUMillicores*0.001), fraction),
-		model.ResourceMemory:  model.ScaleResource(model.MemoryAmountFromBytes(*podMinMemoryMb*1024*1024), fraction),
-		model.ResourceRSS:     model.ScaleResource(model.MemoryAmountFromBytes(*podMinRSSMb*1024*1024), fraction),
-		model.ResourceJVMHeap: model.ScaleResource(model.MemoryAmountFromBytes(*podMinJVMHeapMb*1024*1024), fraction),
+		model.ResourceCPU:              model.ScaleResource(model.CPUAmountFromCores(*podMinCPUMillicores*0.001), fraction),
+		model.ResourceMemory:           model.ScaleResource(model.MemoryAmountFromBytes(*podMinMemoryMb*1024*1024), fraction),
+		model.ResourceRSS:              model.ScaleResource(model.MemoryAmountFromBytes(*podMinRSSMb*1024*1024), fraction),
+		model.ResourceJVMHeapCommitted: model.ScaleResource(model.MemoryAmountFromBytes(*podMinJVMHeapCommittedMb*1024*1024), fraction),
 	}
 
 	recommender := &podResourceRecommender{

--- a/vertical-pod-autoscaler/pkg/recommender/logic/recommender_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/recommender_test.go
@@ -25,7 +25,7 @@ import (
 func TestMinResourcesApplied(t *testing.T) {
 	constEstimator := NewConstEstimator(model.Resources{
 		model.ResourceCPU:    model.CPUAmountFromCores(0.001),
-		model.ResourceMemory: model.MemoryAmountFromBytes(1e6),
+		model.ResourceMemory: model.MemoryAmountFromBytes(0),
 	})
 	recommender := podResourceRecommender{
 		constEstimator,
@@ -44,7 +44,7 @@ func TestMinResourcesApplied(t *testing.T) {
 func TestMinResourcesSplitAcrossContainers(t *testing.T) {
 	constEstimator := NewConstEstimator(model.Resources{
 		model.ResourceCPU:    model.CPUAmountFromCores(0.001),
-		model.ResourceMemory: model.MemoryAmountFromBytes(1e6),
+		model.ResourceMemory: model.MemoryAmountFromBytes(0),
 	})
 	recommender := podResourceRecommender{
 		constEstimator,

--- a/vertical-pod-autoscaler/pkg/recommender/logic/recommender_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/recommender_test.go
@@ -66,7 +66,7 @@ func TestMinResourcesSplitAcrossContainers(t *testing.T) {
 func TestControlledResourcesFiltered(t *testing.T) {
 	constEstimator := NewConstEstimator(model.Resources{
 		model.ResourceCPU:    model.CPUAmountFromCores(0.001),
-		model.ResourceMemory: model.MemoryAmountFromBytes(0),
+		model.ResourceMemory: model.MemoryAmountFromBytes(1e6),
 	})
 	recommender := podResourceRecommender{
 		constEstimator,
@@ -92,7 +92,7 @@ func TestControlledResourcesFiltered(t *testing.T) {
 func TestControlledResourcesFilteredDefault(t *testing.T) {
 	constEstimator := NewConstEstimator(model.Resources{
 		model.ResourceCPU:    model.CPUAmountFromCores(0.001),
-		model.ResourceMemory: model.MemoryAmountFromBytes(0),
+		model.ResourceMemory: model.MemoryAmountFromBytes(1e6),
 	})
 	recommender := podResourceRecommender{
 		constEstimator,

--- a/vertical-pod-autoscaler/pkg/recommender/logic/recommender_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/recommender_test.go
@@ -25,7 +25,7 @@ import (
 func TestMinResourcesApplied(t *testing.T) {
 	constEstimator := NewConstEstimator(model.Resources{
 		model.ResourceCPU:    model.CPUAmountFromCores(0.001),
-		model.ResourceMemory: model.MemoryAmountFromBytes(1e6),
+		model.ResourceMemory: model.MemoryAmountFromBytes(0),
 	})
 	recommender := podResourceRecommender{
 		constEstimator,
@@ -44,7 +44,7 @@ func TestMinResourcesApplied(t *testing.T) {
 func TestMinResourcesSplitAcrossContainers(t *testing.T) {
 	constEstimator := NewConstEstimator(model.Resources{
 		model.ResourceCPU:    model.CPUAmountFromCores(0.001),
-		model.ResourceMemory: model.MemoryAmountFromBytes(1e6),
+		model.ResourceMemory: model.MemoryAmountFromBytes(0),
 	})
 	recommender := podResourceRecommender{
 		constEstimator,
@@ -66,7 +66,7 @@ func TestMinResourcesSplitAcrossContainers(t *testing.T) {
 func TestControlledResourcesFiltered(t *testing.T) {
 	constEstimator := NewConstEstimator(model.Resources{
 		model.ResourceCPU:    model.CPUAmountFromCores(0.001),
-		model.ResourceMemory: model.MemoryAmountFromBytes(1e6),
+		model.ResourceMemory: model.MemoryAmountFromBytes(0),
 	})
 	recommender := podResourceRecommender{
 		constEstimator,
@@ -92,7 +92,7 @@ func TestControlledResourcesFiltered(t *testing.T) {
 func TestControlledResourcesFilteredDefault(t *testing.T) {
 	constEstimator := NewConstEstimator(model.Resources{
 		model.ResourceCPU:    model.CPUAmountFromCores(0.001),
-		model.ResourceMemory: model.MemoryAmountFromBytes(1e6),
+		model.ResourceMemory: model.MemoryAmountFromBytes(0),
 	})
 	recommender := podResourceRecommender{
 		constEstimator,

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -146,7 +146,7 @@ func main() {
 		source = input_metrics.NewExternalClient(config, clusterState, *externalClientOptions)
 	} else {
 		klog.V(1).Infof("Using Metrics Server.")
-		source = input_metrics.NewPodMetricsesSource(resourceclient.NewForConfigOrDie(config))
+		source = input_metrics.NewPodMetricsesSource(resourceclient.NewForConfigOrDie(config), *prometheusAddress)
 	}
 
 	clusterStateFeeder := input.ClusterStateFeederFactory{

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
@@ -59,8 +59,8 @@ const (
 )
 
 var (
-	// TODO: Remove ResourceRSS from default (requires updating all our VPAs to include ResourceRSS in container policies).
 	// DefaultControlledResources is a default value of Spec.ResourcePolicy.ContainerPolicies[].ControlledResources.
+	// TODO: Remove ResourceRSS from default (requires updating all our VPAs to include ResourceRSS in container policies).
 	DefaultControlledResources = []ResourceName{ResourceCPU, ResourceMemory, ResourceRSS}
 )
 

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
@@ -60,7 +60,7 @@ const (
 
 var (
 	// DefaultControlledResources is a default value of Spec.ResourcePolicy.ContainerPolicies[].ControlledResources.
-	DefaultControlledResources = []ResourceName{ResourceCPU, ResourceMemory}
+	DefaultControlledResources = []ResourceName{ResourceCPU, ResourceMemory, ResourceRSS}
 )
 
 // ContainerStateAggregator is an interface for objects that consume and
@@ -94,6 +94,9 @@ type AggregateContainerState struct {
 	// AggregateMemoryPeaks is a distribution of memory peaks from all containers:
 	// each container should add one peak per memory aggregation interval (e.g. once every 24h).
 	AggregateMemoryPeaks util.Histogram
+	// RSSBytes is the max 5m-average RSS observed of all RSS samples (naive implementation).
+	// TODO: aggregate properly with histogram once VPACheckpoint updated to support additional histogram.
+	RSSBytes float64
 	// Note: first/last sample timestamps as well as the sample count are based only on CPU samples.
 	FirstSampleStart  time.Time
 	LastSampleStart   time.Time
@@ -157,6 +160,7 @@ func (a *AggregateContainerState) MarkNotAutoscaled() {
 func (a *AggregateContainerState) MergeContainerState(other *AggregateContainerState) {
 	a.AggregateCPUUsage.Merge(other.AggregateCPUUsage)
 	a.AggregateMemoryPeaks.Merge(other.AggregateMemoryPeaks)
+	a.RSSBytes = math.Max(a.RSSBytes, other.RSSBytes)
 
 	if a.FirstSampleStart.IsZero() ||
 		(!other.FirstSampleStart.IsZero() && other.FirstSampleStart.Before(a.FirstSampleStart)) {
@@ -174,6 +178,7 @@ func NewAggregateContainerState() *AggregateContainerState {
 	return &AggregateContainerState{
 		AggregateCPUUsage:    util.NewDecayingHistogram(config.CPUHistogramOptions, config.CPUHistogramDecayHalfLife),
 		AggregateMemoryPeaks: util.NewDecayingHistogram(config.MemoryHistogramOptions, config.MemoryHistogramDecayHalfLife),
+		RSSBytes:             0,
 		CreationTime:         time.Now(),
 	}
 }
@@ -185,6 +190,8 @@ func (a *AggregateContainerState) AddSample(sample *ContainerUsageSample) {
 		a.addCPUSample(sample)
 	case ResourceMemory:
 		a.AggregateMemoryPeaks.AddSample(BytesFromMemoryAmount(sample.Usage), 1.0, sample.MeasureStart)
+	case ResourceRSS:
+		a.addRSSSample(sample)
 	default:
 		panic(fmt.Sprintf("AddSample doesn't support resource '%s'", sample.Resource))
 	}
@@ -212,6 +219,19 @@ func (a *AggregateContainerState) addCPUSample(sample *ContainerUsageSample) {
 	// which helps react quickly to CPU starvation.
 	a.AggregateCPUUsage.AddSample(
 		cpuUsageCores, math.Max(cpuRequestCores, minSampleWeight), sample.MeasureStart)
+	if sample.MeasureStart.After(a.LastSampleStart) {
+		a.LastSampleStart = sample.MeasureStart
+	}
+	if a.FirstSampleStart.IsZero() || sample.MeasureStart.Before(a.FirstSampleStart) {
+		a.FirstSampleStart = sample.MeasureStart
+	}
+	a.TotalSamplesCount++
+}
+
+func (a *AggregateContainerState) addRSSSample(sample *ContainerUsageSample) {
+	// RSSBytes is the max 5m-average RSS observed of all RSS samples (naive implementation).
+	// TODO: aggregate properly with histogram once VPACheckpoint updated to support additional histogram.
+	a.RSSBytes = math.Max(a.RSSBytes, BytesFromMemoryAmount(sample.Usage))
 	if sample.MeasureStart.After(a.LastSampleStart) {
 		a.LastSampleStart = sample.MeasureStart
 	}

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
@@ -59,6 +59,7 @@ const (
 )
 
 var (
+	// TODO: Remove ResourceRSS from default (requires updating all our VPAs to include ResourceRSS in container policies).
 	// DefaultControlledResources is a default value of Spec.ResourcePolicy.ContainerPolicies[].ControlledResources.
 	DefaultControlledResources = []ResourceName{ResourceCPU, ResourceMemory, ResourceRSS}
 )
@@ -95,7 +96,7 @@ type AggregateContainerState struct {
 	// each container should add one peak per memory aggregation interval (e.g. once every 24h).
 	AggregateMemoryPeaks util.Histogram
 	// RSSBytes is the max 5m-average RSS observed of all RSS samples (naive implementation).
-	// TODO: aggregate properly with histogram once VPACheckpoint updated to support additional histogram.
+	// TODO: Aggregate properly with histogram once VPACheckpoint updated to support additional histogram.
 	RSSBytes float64
 	// Note: first/last sample timestamps as well as the sample count are based only on CPU samples.
 	FirstSampleStart  time.Time
@@ -230,7 +231,7 @@ func (a *AggregateContainerState) addCPUSample(sample *ContainerUsageSample) {
 
 func (a *AggregateContainerState) addRSSSample(sample *ContainerUsageSample) {
 	// RSSBytes is the max 5m-average RSS observed of all RSS samples (naive implementation).
-	// TODO: aggregate properly with histogram once VPACheckpoint updated to support additional histogram.
+	// TODO: Aggregate properly with histogram once VPACheckpoint updated to support additional histogram.
 	a.RSSBytes = math.Max(a.RSSBytes, BytesFromMemoryAmount(sample.Usage))
 	if sample.MeasureStart.After(a.LastSampleStart) {
 		a.LastSampleStart = sample.MeasureStart

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
@@ -181,11 +181,11 @@ func (a *AggregateContainerState) MergeContainerState(other *AggregateContainerS
 func NewAggregateContainerState() *AggregateContainerState {
 	config := GetAggregationsConfig()
 	return &AggregateContainerState{
-		AggregateCPUUsage:    util.NewDecayingHistogram(config.CPUHistogramOptions, config.CPUHistogramDecayHalfLife),
-		AggregateMemoryPeaks: util.NewDecayingHistogram(config.MemoryHistogramOptions, config.MemoryHistogramDecayHalfLife),
-		RSSBytes:             0,
-		JVMHeapCommittedBytes:         0,
-		CreationTime:         time.Now(),
+		AggregateCPUUsage:     util.NewDecayingHistogram(config.CPUHistogramOptions, config.CPUHistogramDecayHalfLife),
+		AggregateMemoryPeaks:  util.NewDecayingHistogram(config.MemoryHistogramOptions, config.MemoryHistogramDecayHalfLife),
+		RSSBytes:              0,
+		JVMHeapCommittedBytes: 0,
+		CreationTime:          time.Now(),
 	}
 }
 

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
@@ -95,12 +95,12 @@ type AggregateContainerState struct {
 	// AggregateMemoryPeaks is a distribution of memory peaks from all containers:
 	// each container should add one peak per memory aggregation interval (e.g. once every 24h).
 	AggregateMemoryPeaks util.Histogram
-	// RSSBytes is the max 5m-average RSS observed of all RSS samples (naive implementation).
-	// TODO: Aggregate properly with histogram once VPACheckpoint updated to support additional histogram.
-	RSSBytes float64
-	// JVMHeapCommittedBytes is the max 5m-average committed JVM Heap observed of all JVM Heap samples (naive implementation).
-	// TODO: Aggregate properly with histogram once VPACheckpoint updated to support additional histogram.
-	JVMHeapCommittedBytes float64
+	// AggregateRSSPeaks is a distribution of RSS peaks from all containers:
+	// each container should add one peak per memory aggregation interval (e.g. once every 24h).
+	AggregateRSSPeaks util.Histogram
+	// AggregateJVMHeapCommittedPeaks is a distribution of committed JVM heap peaks from all containers:
+	// each container should add one peak per memory aggregation interval (e.g. once every 24h).
+	AggregateJVMHeapCommittedPeaks util.Histogram
 	// Note: first/last sample timestamps as well as the sample count are based only on CPU samples.
 	FirstSampleStart  time.Time
 	LastSampleStart   time.Time
@@ -164,8 +164,8 @@ func (a *AggregateContainerState) MarkNotAutoscaled() {
 func (a *AggregateContainerState) MergeContainerState(other *AggregateContainerState) {
 	a.AggregateCPUUsage.Merge(other.AggregateCPUUsage)
 	a.AggregateMemoryPeaks.Merge(other.AggregateMemoryPeaks)
-	a.RSSBytes = math.Max(a.RSSBytes, other.RSSBytes)
-	a.JVMHeapCommittedBytes = math.Max(a.JVMHeapCommittedBytes, other.JVMHeapCommittedBytes)
+	a.AggregateRSSPeaks.Merge(other.AggregateRSSPeaks)
+	a.AggregateJVMHeapCommittedPeaks.Merge(other.AggregateJVMHeapCommittedPeaks)
 
 	if a.FirstSampleStart.IsZero() ||
 		(!other.FirstSampleStart.IsZero() && other.FirstSampleStart.Before(a.FirstSampleStart)) {
@@ -181,11 +181,12 @@ func (a *AggregateContainerState) MergeContainerState(other *AggregateContainerS
 func NewAggregateContainerState() *AggregateContainerState {
 	config := GetAggregationsConfig()
 	return &AggregateContainerState{
-		AggregateCPUUsage:     util.NewDecayingHistogram(config.CPUHistogramOptions, config.CPUHistogramDecayHalfLife),
-		AggregateMemoryPeaks:  util.NewDecayingHistogram(config.MemoryHistogramOptions, config.MemoryHistogramDecayHalfLife),
-		RSSBytes:              0,
-		JVMHeapCommittedBytes: 0,
-		CreationTime:          time.Now(),
+		AggregateCPUUsage:    util.NewDecayingHistogram(config.CPUHistogramOptions, config.CPUHistogramDecayHalfLife),
+		AggregateMemoryPeaks: util.NewDecayingHistogram(config.MemoryHistogramOptions, config.MemoryHistogramDecayHalfLife),
+		// TODO: Use individual config for RSS and JVMHeapCommitted.
+		AggregateRSSPeaks:              util.NewDecayingHistogram(config.MemoryHistogramOptions, config.MemoryHistogramDecayHalfLife),
+		AggregateJVMHeapCommittedPeaks: util.NewDecayingHistogram(config.MemoryHistogramOptions, config.MemoryHistogramDecayHalfLife),
+		CreationTime:                   time.Now(),
 	}
 }
 
@@ -197,9 +198,9 @@ func (a *AggregateContainerState) AddSample(sample *ContainerUsageSample) {
 	case ResourceMemory:
 		a.AggregateMemoryPeaks.AddSample(BytesFromMemoryAmount(sample.Usage), 1.0, sample.MeasureStart)
 	case ResourceRSS:
-		a.addRSSSample(sample)
+		a.AggregateRSSPeaks.AddSample(BytesFromMemoryAmount(sample.Usage), 1.0, sample.MeasureStart)
 	case ResourceJVMHeapCommitted:
-		a.addJVMHeapCommittedSample(sample)
+		a.AggregateJVMHeapCommittedPeaks.AddSample(BytesFromMemoryAmount(sample.Usage), 1.0, sample.MeasureStart)
 	default:
 		panic(fmt.Sprintf("AddSample doesn't support resource '%s'", sample.Resource))
 	}
@@ -214,6 +215,10 @@ func (a *AggregateContainerState) SubtractSample(sample *ContainerUsageSample) {
 	switch sample.Resource {
 	case ResourceMemory:
 		a.AggregateMemoryPeaks.SubtractSample(BytesFromMemoryAmount(sample.Usage), 1.0, sample.MeasureStart)
+	case ResourceRSS:
+		a.AggregateRSSPeaks.SubtractSample(BytesFromMemoryAmount(sample.Usage), 1.0, sample.MeasureStart)
+	case ResourceJVMHeapCommitted:
+		a.AggregateJVMHeapCommittedPeaks.SubtractSample(BytesFromMemoryAmount(sample.Usage), 1.0, sample.MeasureStart)
 	default:
 		panic(fmt.Sprintf("SubtractSample doesn't support resource '%s'", sample.Resource))
 	}
@@ -236,32 +241,6 @@ func (a *AggregateContainerState) addCPUSample(sample *ContainerUsageSample) {
 	a.TotalSamplesCount++
 }
 
-func (a *AggregateContainerState) addRSSSample(sample *ContainerUsageSample) {
-	// RSSBytes is the max 5m-average RSS observed of all RSS samples (naive implementation).
-	// TODO: Aggregate properly with histogram once VPACheckpoint updated to support additional histogram.
-	a.RSSBytes = math.Max(a.RSSBytes, BytesFromMemoryAmount(sample.Usage))
-	if sample.MeasureStart.After(a.LastSampleStart) {
-		a.LastSampleStart = sample.MeasureStart
-	}
-	if a.FirstSampleStart.IsZero() || sample.MeasureStart.Before(a.FirstSampleStart) {
-		a.FirstSampleStart = sample.MeasureStart
-	}
-	a.TotalSamplesCount++
-}
-
-func (a *AggregateContainerState) addJVMHeapCommittedSample(sample *ContainerUsageSample) {
-	// JVMHeapCommittedBytes is the max 5m-average committed JVM Heap observed of all JVM Heap samples (naive implementation).
-	// TODO: Aggregate properly with histogram once VPACheckpoint updated to support additional histogram.
-	a.JVMHeapCommittedBytes = math.Max(a.JVMHeapCommittedBytes, BytesFromMemoryAmount(sample.Usage))
-	if sample.MeasureStart.After(a.LastSampleStart) {
-		a.LastSampleStart = sample.MeasureStart
-	}
-	if a.FirstSampleStart.IsZero() || sample.MeasureStart.Before(a.FirstSampleStart) {
-		a.FirstSampleStart = sample.MeasureStart
-	}
-	a.TotalSamplesCount++
-}
-
 // SaveToCheckpoint serializes AggregateContainerState as VerticalPodAutoscalerCheckpointStatus.
 // The serialization may result in loss of precission of the histograms.
 func (a *AggregateContainerState) SaveToCheckpoint() (*vpa_types.VerticalPodAutoscalerCheckpointStatus, error) {
@@ -273,14 +252,24 @@ func (a *AggregateContainerState) SaveToCheckpoint() (*vpa_types.VerticalPodAuto
 	if err != nil {
 		return nil, err
 	}
+	rss, err := a.AggregateRSSPeaks.SaveToChekpoint()
+	if err != nil {
+		return nil, err
+	}
+	jvmHeapCommitted, err := a.AggregateJVMHeapCommittedPeaks.SaveToChekpoint()
+	if err != nil {
+		return nil, err
+	}
 	return &vpa_types.VerticalPodAutoscalerCheckpointStatus{
-		LastUpdateTime:    metav1.NewTime(time.Now()),
-		FirstSampleStart:  metav1.NewTime(a.FirstSampleStart),
-		LastSampleStart:   metav1.NewTime(a.LastSampleStart),
-		TotalSamplesCount: a.TotalSamplesCount,
-		MemoryHistogram:   *memory,
-		CPUHistogram:      *cpu,
-		Version:           SupportedCheckpointVersion,
+		LastUpdateTime:            metav1.NewTime(time.Now()),
+		FirstSampleStart:          metav1.NewTime(a.FirstSampleStart),
+		LastSampleStart:           metav1.NewTime(a.LastSampleStart),
+		TotalSamplesCount:         a.TotalSamplesCount,
+		MemoryHistogram:           *memory,
+		CPUHistogram:              *cpu,
+		RSSHistogram:              *rss,
+		JVMHeapCommittedHistogram: *jvmHeapCommitted,
+		Version:                   SupportedCheckpointVersion,
 	}, nil
 }
 
@@ -298,6 +287,14 @@ func (a *AggregateContainerState) LoadFromCheckpoint(checkpoint *vpa_types.Verti
 		return err
 	}
 	err = a.AggregateCPUUsage.LoadFromCheckpoint(&checkpoint.CPUHistogram)
+	if err != nil {
+		return err
+	}
+	err = a.AggregateRSSPeaks.LoadFromCheckpoint(&checkpoint.RSSHistogram)
+	if err != nil {
+		return err
+	}
+	err = a.AggregateJVMHeapCommittedPeaks.LoadFromCheckpoint(&checkpoint.JVMHeapCommittedHistogram)
 	if err != nil {
 		return err
 	}

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
@@ -60,8 +60,8 @@ const (
 
 var (
 	// DefaultControlledResources is a default value of Spec.ResourcePolicy.ContainerPolicies[].ControlledResources.
-	// TODO: Remove ResourceRSS/JVMHeap from default (requires updating all our VPAs to include ResourceRSS/JVMHeap in container policies).
-	DefaultControlledResources = []ResourceName{ResourceCPU, ResourceMemory, ResourceRSS, ResourceJVMHeap}
+	// TODO: Remove ResourceRSS/JVMHeapCommitted from default (requires updating all our VPAs to include ResourceRSS/JVMHeapCommitted in container policies).
+	DefaultControlledResources = []ResourceName{ResourceCPU, ResourceMemory, ResourceRSS, ResourceJVMHeapCommitted}
 )
 
 // ContainerStateAggregator is an interface for objects that consume and
@@ -98,9 +98,9 @@ type AggregateContainerState struct {
 	// RSSBytes is the max 5m-average RSS observed of all RSS samples (naive implementation).
 	// TODO: Aggregate properly with histogram once VPACheckpoint updated to support additional histogram.
 	RSSBytes float64
-	// JVMHeapBytes is the max 5m-average committed JVM Heap observed of all JVM Heap samples (naive implementation).
+	// JVMHeapCommittedBytes is the max 5m-average committed JVM Heap observed of all JVM Heap samples (naive implementation).
 	// TODO: Aggregate properly with histogram once VPACheckpoint updated to support additional histogram.
-	JVMHeapBytes float64
+	JVMHeapCommittedBytes float64
 	// Note: first/last sample timestamps as well as the sample count are based only on CPU samples.
 	FirstSampleStart  time.Time
 	LastSampleStart   time.Time
@@ -165,7 +165,7 @@ func (a *AggregateContainerState) MergeContainerState(other *AggregateContainerS
 	a.AggregateCPUUsage.Merge(other.AggregateCPUUsage)
 	a.AggregateMemoryPeaks.Merge(other.AggregateMemoryPeaks)
 	a.RSSBytes = math.Max(a.RSSBytes, other.RSSBytes)
-	a.JVMHeapBytes = math.Max(a.JVMHeapBytes, other.JVMHeapBytes)
+	a.JVMHeapCommittedBytes = math.Max(a.JVMHeapCommittedBytes, other.JVMHeapCommittedBytes)
 
 	if a.FirstSampleStart.IsZero() ||
 		(!other.FirstSampleStart.IsZero() && other.FirstSampleStart.Before(a.FirstSampleStart)) {
@@ -184,7 +184,7 @@ func NewAggregateContainerState() *AggregateContainerState {
 		AggregateCPUUsage:    util.NewDecayingHistogram(config.CPUHistogramOptions, config.CPUHistogramDecayHalfLife),
 		AggregateMemoryPeaks: util.NewDecayingHistogram(config.MemoryHistogramOptions, config.MemoryHistogramDecayHalfLife),
 		RSSBytes:             0,
-		JVMHeapBytes:         0,
+		JVMHeapCommittedBytes:         0,
 		CreationTime:         time.Now(),
 	}
 }
@@ -198,8 +198,8 @@ func (a *AggregateContainerState) AddSample(sample *ContainerUsageSample) {
 		a.AggregateMemoryPeaks.AddSample(BytesFromMemoryAmount(sample.Usage), 1.0, sample.MeasureStart)
 	case ResourceRSS:
 		a.addRSSSample(sample)
-	case ResourceJVMHeap:
-		a.addJVMHeapSample(sample)
+	case ResourceJVMHeapCommitted:
+		a.addJVMHeapCommittedSample(sample)
 	default:
 		panic(fmt.Sprintf("AddSample doesn't support resource '%s'", sample.Resource))
 	}
@@ -249,10 +249,10 @@ func (a *AggregateContainerState) addRSSSample(sample *ContainerUsageSample) {
 	a.TotalSamplesCount++
 }
 
-func (a *AggregateContainerState) addJVMHeapSample(sample *ContainerUsageSample) {
-	// JVMHeapBytes is the max 5m-average committed JVM Heap observed of all JVM Heap samples (naive implementation).
+func (a *AggregateContainerState) addJVMHeapCommittedSample(sample *ContainerUsageSample) {
+	// JVMHeapCommittedBytes is the max 5m-average committed JVM Heap observed of all JVM Heap samples (naive implementation).
 	// TODO: Aggregate properly with histogram once VPACheckpoint updated to support additional histogram.
-	a.JVMHeapBytes = math.Max(a.JVMHeapBytes, BytesFromMemoryAmount(sample.Usage))
+	a.JVMHeapCommittedBytes = math.Max(a.JVMHeapCommittedBytes, BytesFromMemoryAmount(sample.Usage))
 	if sample.MeasureStart.After(a.LastSampleStart) {
 		a.LastSampleStart = sample.MeasureStart
 	}

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state_test.go
@@ -279,11 +279,11 @@ func TestUpdateFromPolicyControlledResources(t *testing.T) {
 		}, {
 			name:     "No ControlledResources specified - used default",
 			policy:   &vpa_types.ContainerResourcePolicy{},
-			expected: []ResourceName{ResourceCPU, ResourceMemory, ResourceRSS, ResourceJVMHeap},
+			expected: []ResourceName{ResourceCPU, ResourceMemory, ResourceRSS, ResourceJVMHeapCommitted},
 		}, {
 			name:     "Nil policy - use default",
 			policy:   nil,
-			expected: []ResourceName{ResourceCPU, ResourceMemory, ResourceRSS, ResourceJVMHeap},
+			expected: []ResourceName{ResourceCPU, ResourceMemory, ResourceRSS, ResourceJVMHeapCommitted},
 		},
 	}
 	for _, tc := range testCases {

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state_test.go
@@ -279,11 +279,11 @@ func TestUpdateFromPolicyControlledResources(t *testing.T) {
 		}, {
 			name:     "No ControlledResources specified - used default",
 			policy:   &vpa_types.ContainerResourcePolicy{},
-			expected: []ResourceName{ResourceCPU, ResourceMemory, ResourceRSS},
+			expected: []ResourceName{ResourceCPU, ResourceMemory, ResourceRSS, ResourceJVMHeap},
 		}, {
 			name:     "Nil policy - use default",
 			policy:   nil,
-			expected: []ResourceName{ResourceCPU, ResourceMemory, ResourceRSS},
+			expected: []ResourceName{ResourceCPU, ResourceMemory, ResourceRSS, ResourceJVMHeap},
 		},
 	}
 	for _, tc := range testCases {

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state_test.go
@@ -119,8 +119,8 @@ func TestAggregateStateByContainerName(t *testing.T) {
 	actualCPUHistogram := aggregateResources["app-A"].AggregateCPUUsage
 
 	expectedMemoryHistogram := util.NewDecayingHistogram(config.MemoryHistogramOptions, config.MemoryHistogramDecayHalfLife)
-	expectedMemoryHistogram.AddSample(2e9, 1.0, cluster.GetContainer(containers[0]).WindowEnd)
-	expectedMemoryHistogram.AddSample(4e9, 1.0, cluster.GetContainer(containers[2]).WindowEnd)
+	expectedMemoryHistogram.AddSample(2e9, 1.0, cluster.GetContainer(containers[0]).MemoryWindowEnd)
+	expectedMemoryHistogram.AddSample(4e9, 1.0, cluster.GetContainer(containers[2]).MemoryWindowEnd)
 	actualMemoryHistogram := aggregateResources["app-A"].AggregateMemoryPeaks
 
 	assert.True(t, expectedCPUHistogram.Equals(actualCPUHistogram), "Expected:\n%s\nActual:\n%s", expectedCPUHistogram, actualCPUHistogram)

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state_test.go
@@ -279,11 +279,11 @@ func TestUpdateFromPolicyControlledResources(t *testing.T) {
 		}, {
 			name:     "No ControlledResources specified - used default",
 			policy:   &vpa_types.ContainerResourcePolicy{},
-			expected: []ResourceName{ResourceCPU, ResourceMemory},
+			expected: []ResourceName{ResourceCPU, ResourceMemory, ResourceRSS},
 		}, {
 			name:     "Nil policy - use default",
 			policy:   nil,
-			expected: []ResourceName{ResourceCPU, ResourceMemory},
+			expected: []ResourceName{ResourceCPU, ResourceMemory, ResourceRSS},
 		},
 	}
 	for _, tc := range testCases {

--- a/vertical-pod-autoscaler/pkg/recommender/model/container.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/container.go
@@ -68,13 +68,13 @@ type ContainerState struct {
 // NewContainerState returns a new ContainerState.
 func NewContainerState(request Resources, aggregator ContainerStateAggregator) *ContainerState {
 	return &ContainerState{
-		Request:                request,
-		LastCPUSampleStart:     time.Time{},
-		WindowEnd:              time.Time{},
-		lastMemorySampleStart:  time.Time{},
-		lastRSSSampleStart:     time.Time{},
+		Request:                         request,
+		LastCPUSampleStart:              time.Time{},
+		WindowEnd:                       time.Time{},
+		lastMemorySampleStart:           time.Time{},
+		lastRSSSampleStart:              time.Time{},
 		lastJVMHeapCommittedSampleStart: time.Time{},
-		aggregator:             aggregator,
+		aggregator:                      aggregator,
 	}
 }
 

--- a/vertical-pod-autoscaler/pkg/recommender/model/container.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/container.go
@@ -60,7 +60,7 @@ type ContainerState struct {
 	// Start of the latest RSS sample that was aggregated.
 	lastRSSSampleStart time.Time
 	// Start of the latest JVM Heap sample that was aggregated.
-	lastJVMHeapSampleStart time.Time
+	lastJVMHeapCommittedSampleStart time.Time
 	// Aggregation to add usage samples to.
 	aggregator ContainerStateAggregator
 }
@@ -73,7 +73,7 @@ func NewContainerState(request Resources, aggregator ContainerStateAggregator) *
 		WindowEnd:              time.Time{},
 		lastMemorySampleStart:  time.Time{},
 		lastRSSSampleStart:     time.Time{},
-		lastJVMHeapSampleStart: time.Time{},
+		lastJVMHeapCommittedSampleStart: time.Time{},
 		aggregator:             aggregator,
 	}
 }
@@ -104,14 +104,14 @@ func (container *ContainerState) addRSSSample(sample *ContainerUsageSample) bool
 	return true
 }
 
-func (container *ContainerState) addJVMHeapSample(sample *ContainerUsageSample) bool {
-	if !sample.isValid(ResourceJVMHeap) || !sample.MeasureStart.After(container.lastJVMHeapSampleStart) {
+func (container *ContainerState) addJVMHeapCommittedSample(sample *ContainerUsageSample) bool {
+	if !sample.isValid(ResourceJVMHeapCommitted) || !sample.MeasureStart.After(container.lastJVMHeapCommittedSampleStart) {
 		return false // Discard invalid, duplicate or out-of-order samples.
 	}
 	// TODO: Observe quality metrics once JVM Heap aggregation moves away from the naive max to by histogram.
-	// container.observeQualityMetrics(sample.Usage, false, corev1.ResourceName(ResourceJVMHeap))
+	// container.observeQualityMetrics(sample.Usage, false, corev1.ResourceName(ResourceJVMHeapCommitted))
 	container.aggregator.AddSample(sample)
-	container.lastJVMHeapSampleStart = sample.MeasureStart
+	container.lastJVMHeapCommittedSampleStart = sample.MeasureStart
 	return true
 }
 
@@ -249,8 +249,8 @@ func (container *ContainerState) AddSample(sample *ContainerUsageSample) bool {
 		return container.addMemorySample(sample, false)
 	case ResourceRSS:
 		return container.addRSSSample(sample)
-	case ResourceJVMHeap:
-		return container.addJVMHeapSample(sample)
+	case ResourceJVMHeapCommitted:
+		return container.addJVMHeapCommittedSample(sample)
 	default:
 		return false
 	}

--- a/vertical-pod-autoscaler/pkg/recommender/model/types.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/types.go
@@ -41,6 +41,8 @@ const (
 	ResourceMemory ResourceName = "memory"
 	// ResourceRSS represents RSS, in bytes.
 	ResourceRSS ResourceName = "rss"
+	// ResourceJVMHeap represents committed JVM Heap, in bytes.
+	ResourceJVMHeap ResourceName = "jvmheap"
 	// MaxResourceAmount is the maximum allowed value of resource amount.
 	MaxResourceAmount = ResourceAmount(1e14)
 )
@@ -96,6 +98,9 @@ func ResourcesAsResourceList(resources Resources) apiv1.ResourceList {
 		case ResourceRSS:
 			newKey = apiv1.ResourceName(ResourceRSS)
 			quantity = QuantityFromMemoryAmount(resourceAmount)
+		case ResourceJVMHeap:
+			newKey = apiv1.ResourceName(ResourceJVMHeap)
+			quantity = QuantityFromMemoryAmount(resourceAmount)
 		default:
 			klog.Errorf("Cannot translate %v resource name", key)
 			continue
@@ -116,6 +121,8 @@ func ResourceNamesApiToModel(resources []apiv1.ResourceName) *[]ResourceName {
 			result = append(result, ResourceMemory)
 		case apiv1.ResourceName(ResourceRSS):
 			result = append(result, ResourceRSS)
+		case apiv1.ResourceName(ResourceJVMHeap):
+			result = append(result, ResourceJVMHeap)
 		default:
 			klog.Errorf("Cannot translate %v resource name", resource)
 			continue

--- a/vertical-pod-autoscaler/pkg/recommender/model/types.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/types.go
@@ -42,7 +42,7 @@ const (
 	// ResourceRSS represents RSS, in bytes.
 	ResourceRSS ResourceName = "rss"
 	// ResourceJVMHeap represents committed JVM Heap, in bytes.
-	ResourceJVMHeap ResourceName = "jvmHeap"
+	ResourceJVMHeap ResourceName = "jvmHeapCommitted"
 	// MaxResourceAmount is the maximum allowed value of resource amount.
 	MaxResourceAmount = ResourceAmount(1e14)
 )

--- a/vertical-pod-autoscaler/pkg/recommender/model/types.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/types.go
@@ -41,6 +41,8 @@ const (
 	ResourceMemory ResourceName = "memory"
 	// ResourceRSS represents RSS, in bytes.
 	ResourceRSS ResourceName = "rss"
+	// ResourceJVMHeap represents committed JVM Heap, in bytes.
+	ResourceJVMHeap ResourceName = "jvmHeapCommitted"
 	// MaxResourceAmount is the maximum allowed value of resource amount.
 	MaxResourceAmount = ResourceAmount(1e14)
 )
@@ -96,6 +98,9 @@ func ResourcesAsResourceList(resources Resources) apiv1.ResourceList {
 		case ResourceRSS:
 			newKey = apiv1.ResourceName(ResourceRSS)
 			quantity = QuantityFromMemoryAmount(resourceAmount)
+		case ResourceJVMHeap:
+			newKey = apiv1.ResourceName(ResourceJVMHeap)
+			quantity = QuantityFromMemoryAmount(resourceAmount)
 		default:
 			klog.Errorf("Cannot translate %v resource name", key)
 			continue
@@ -116,6 +121,8 @@ func ResourceNamesApiToModel(resources []apiv1.ResourceName) *[]ResourceName {
 			result = append(result, ResourceMemory)
 		case apiv1.ResourceName(ResourceRSS):
 			result = append(result, ResourceRSS)
+		case apiv1.ResourceName(ResourceJVMHeap):
+			result = append(result, ResourceJVMHeap)
 		default:
 			klog.Errorf("Cannot translate %v resource name", resource)
 			continue

--- a/vertical-pod-autoscaler/pkg/recommender/model/types.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/types.go
@@ -41,8 +41,8 @@ const (
 	ResourceMemory ResourceName = "memory"
 	// ResourceRSS represents RSS, in bytes.
 	ResourceRSS ResourceName = "rss"
-	// ResourceJVMHeap represents committed JVM Heap, in bytes.
-	ResourceJVMHeap ResourceName = "jvmHeapCommitted"
+	// ResourceJVMHeapCommitted represents committed JVM Heap, in bytes.
+	ResourceJVMHeapCommitted ResourceName = "jvmHeapCommitted"
 	// MaxResourceAmount is the maximum allowed value of resource amount.
 	MaxResourceAmount = ResourceAmount(1e14)
 )
@@ -98,8 +98,8 @@ func ResourcesAsResourceList(resources Resources) apiv1.ResourceList {
 		case ResourceRSS:
 			newKey = apiv1.ResourceName(ResourceRSS)
 			quantity = QuantityFromMemoryAmount(resourceAmount)
-		case ResourceJVMHeap:
-			newKey = apiv1.ResourceName(ResourceJVMHeap)
+		case ResourceJVMHeapCommitted:
+			newKey = apiv1.ResourceName(ResourceJVMHeapCommitted)
 			quantity = QuantityFromMemoryAmount(resourceAmount)
 		default:
 			klog.Errorf("Cannot translate %v resource name", key)
@@ -121,8 +121,8 @@ func ResourceNamesApiToModel(resources []apiv1.ResourceName) *[]ResourceName {
 			result = append(result, ResourceMemory)
 		case apiv1.ResourceName(ResourceRSS):
 			result = append(result, ResourceRSS)
-		case apiv1.ResourceName(ResourceJVMHeap):
-			result = append(result, ResourceJVMHeap)
+		case apiv1.ResourceName(ResourceJVMHeapCommitted):
+			result = append(result, ResourceJVMHeapCommitted)
 		default:
 			klog.Errorf("Cannot translate %v resource name", resource)
 			continue

--- a/vertical-pod-autoscaler/pkg/recommender/model/types.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/types.go
@@ -39,6 +39,8 @@ const (
 	ResourceCPU ResourceName = "cpu"
 	// ResourceMemory represents memory, in bytes. (500Gi = 500GiB = 500 * 1024 * 1024 * 1024).
 	ResourceMemory ResourceName = "memory"
+	// ResourceRSS represents RSS, in bytes.
+	ResourceRSS ResourceName = "rss"
 	// MaxResourceAmount is the maximum allowed value of resource amount.
 	MaxResourceAmount = ResourceAmount(1e14)
 )
@@ -91,6 +93,9 @@ func ResourcesAsResourceList(resources Resources) apiv1.ResourceList {
 		case ResourceMemory:
 			newKey = apiv1.ResourceMemory
 			quantity = QuantityFromMemoryAmount(resourceAmount)
+		case ResourceRSS:
+			newKey = apiv1.ResourceName(ResourceRSS)
+			quantity = QuantityFromMemoryAmount(resourceAmount)
 		default:
 			klog.Errorf("Cannot translate %v resource name", key)
 			continue
@@ -109,6 +114,8 @@ func ResourceNamesApiToModel(resources []apiv1.ResourceName) *[]ResourceName {
 			result = append(result, ResourceCPU)
 		case apiv1.ResourceMemory:
 			result = append(result, ResourceMemory)
+		case apiv1.ResourceName(ResourceRSS):
+			result = append(result, ResourceRSS)
 		default:
 			klog.Errorf("Cannot translate %v resource name", resource)
 			continue

--- a/vertical-pod-autoscaler/pkg/recommender/model/types.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/types.go
@@ -42,7 +42,7 @@ const (
 	// ResourceRSS represents RSS, in bytes.
 	ResourceRSS ResourceName = "rss"
 	// ResourceJVMHeap represents committed JVM Heap, in bytes.
-	ResourceJVMHeap ResourceName = "jvmheap"
+	ResourceJVMHeap ResourceName = "jvmHeap"
 	// MaxResourceAmount is the maximum allowed value of resource amount.
 	MaxResourceAmount = ResourceAmount(1e14)
 )


### PR DESCRIPTION
Replaces the naive `max` recommendation implementations for RSS (https://github.com/jodzga/autoscaler/pull/8) and committed JVM heap (https://github.com/jodzga/autoscaler/pull/9) with the same histogram-based recommendation strategy as the native `memory` recommendation. Essentially, every aggregation interval, we will collect the 1 peak value and add it to the histogram.

Note that we ignore OOMKills and use the same opts as memory (e.g. aggregation interval, count, and percentile) for now.