### PR TITLE
Checkpoint RSS + JVM heap historical usage with histograms

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
+++ b/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
@@ -144,7 +144,13 @@ func buildAggregateContainerStateMap(vpa *model.Vpa, cluster *model.ClusterState
 }
 
 func subtractCurrentContainerMemoryPeak(a *model.AggregateContainerState, container *model.ContainerState, now time.Time) {
-	if now.Before(container.WindowEnd) {
-		a.AggregateMemoryPeaks.SubtractSample(model.BytesFromMemoryAmount(container.GetMaxMemoryPeak()), 1.0, container.WindowEnd)
+	if now.Before(container.MemoryWindowEnd) {
+		a.AggregateMemoryPeaks.SubtractSample(model.BytesFromMemoryAmount(container.GetMaxMemoryPeak()), 1.0, container.MemoryWindowEnd)
+	}
+	if now.Before(container.RSSWindowEnd) {
+		a.AggregateRSSPeaks.SubtractSample(model.BytesFromMemoryAmount(container.GetMaxRSSPeak()), 1.0, container.RSSWindowEnd)
+	}
+	if now.Before(container.JVMHeapCommittedWindowEnd) {
+		a.AggregateJVMHeapCommittedPeaks.SubtractSample(model.BytesFromMemoryAmount(container.GetMaxJVMHeapCommittedPeak()), 1.0, container.JVMHeapCommittedWindowEnd)
 	}
 }

--- a/vertical-pod-autoscaler/pkg/recommender/logic/estimator.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/estimator.go
@@ -100,9 +100,9 @@ func (e *percentileEstimator) GetResourceEstimation(s *model.AggregateContainerS
 			s.AggregateCPUUsage.Percentile(e.cpuPercentile)),
 		model.ResourceMemory: model.MemoryAmountFromBytes(
 			s.AggregateMemoryPeaks.Percentile(e.memoryPercentile)),
-		// TODO: Take percentile once RSS + JVM Heap aggregation moves away from the naive max to by histogram.
-		model.ResourceRSS:              model.MemoryAmountFromBytes(s.RSSBytes),
-		model.ResourceJVMHeapCommitted: model.MemoryAmountFromBytes(s.JVMHeapCommittedBytes),
+		// TODO: Use individual config for RSS and JVMHeapCommitted.
+		model.ResourceRSS:              model.MemoryAmountFromBytes(s.AggregateRSSPeaks.Percentile(e.memoryPercentile)),
+		model.ResourceJVMHeapCommitted: model.MemoryAmountFromBytes(s.AggregateJVMHeapCommittedPeaks.Percentile(e.memoryPercentile)),
 	}
 }
 

--- a/vertical-pod-autoscaler/pkg/recommender/logic/estimator_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/estimator_test.go
@@ -54,8 +54,10 @@ func TestPercentileEstimator(t *testing.T) {
 
 	resourceEstimation := estimator.GetResourceEstimation(
 		&model.AggregateContainerState{
-			AggregateCPUUsage:    cpuHistogram,
-			AggregateMemoryPeaks: memoryPeaksHistogram,
+			AggregateCPUUsage:              cpuHistogram,
+			AggregateMemoryPeaks:           memoryPeaksHistogram,
+			AggregateRSSPeaks:              memoryPeaksHistogram,
+			AggregateJVMHeapCommittedPeaks: memoryPeaksHistogram,
 		})
 	maxRelativeError := 0.05 // Allow 5% relative error to account for histogram rounding.
 	assert.InEpsilon(t, 1.0, model.CoresFromCPUAmount(resourceEstimation[model.ResourceCPU]), maxRelativeError)

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
@@ -95,12 +95,12 @@ type AggregateContainerState struct {
 	// AggregateMemoryPeaks is a distribution of memory peaks from all containers:
 	// each container should add one peak per memory aggregation interval (e.g. once every 24h).
 	AggregateMemoryPeaks util.Histogram
-	// RSSBytes is the max 5m-average RSS observed of all RSS samples (naive implementation).
-	// TODO: Aggregate properly with histogram once VPACheckpoint updated to support additional histogram.
-	RSSBytes float64
-	// JVMHeapCommittedBytes is the max 5m-average committed JVM Heap observed of all JVM Heap samples (naive implementation).
-	// TODO: Aggregate properly with histogram once VPACheckpoint updated to support additional histogram.
-	JVMHeapCommittedBytes float64
+	// AggregateRSSPeaks is a distribution of RSS peaks from all containers:
+	// each container should add one peak per memory aggregation interval (e.g. once every 24h).
+	AggregateRSSPeaks util.Histogram
+	// AggregateJVMHeapCommittedPeaks is a distribution of committed JVM heap peaks from all containers:
+	// each container should add one peak per memory aggregation interval (e.g. once every 24h).
+	AggregateJVMHeapCommittedPeaks util.Histogram
 	// Note: first/last sample timestamps as well as the sample count are based only on CPU samples.
 	FirstSampleStart  time.Time
 	LastSampleStart   time.Time
@@ -164,8 +164,8 @@ func (a *AggregateContainerState) MarkNotAutoscaled() {
 func (a *AggregateContainerState) MergeContainerState(other *AggregateContainerState) {
 	a.AggregateCPUUsage.Merge(other.AggregateCPUUsage)
 	a.AggregateMemoryPeaks.Merge(other.AggregateMemoryPeaks)
-	a.RSSBytes = math.Max(a.RSSBytes, other.RSSBytes)
-	a.JVMHeapCommittedBytes = math.Max(a.JVMHeapCommittedBytes, other.JVMHeapCommittedBytes)
+	a.AggregateRSSPeaks.Merge(other.AggregateRSSPeaks)
+	a.AggregateJVMHeapCommittedPeaks.Merge(other.AggregateJVMHeapCommittedPeaks)
 
 	if a.FirstSampleStart.IsZero() ||
 		(!other.FirstSampleStart.IsZero() && other.FirstSampleStart.Before(a.FirstSampleStart)) {
@@ -181,11 +181,12 @@ func (a *AggregateContainerState) MergeContainerState(other *AggregateContainerS
 func NewAggregateContainerState() *AggregateContainerState {
 	config := GetAggregationsConfig()
 	return &AggregateContainerState{
-		AggregateCPUUsage:     util.NewDecayingHistogram(config.CPUHistogramOptions, config.CPUHistogramDecayHalfLife),
-		AggregateMemoryPeaks:  util.NewDecayingHistogram(config.MemoryHistogramOptions, config.MemoryHistogramDecayHalfLife),
-		RSSBytes:              0,
-		JVMHeapCommittedBytes: 0,
-		CreationTime:          time.Now(),
+		AggregateCPUUsage:    util.NewDecayingHistogram(config.CPUHistogramOptions, config.CPUHistogramDecayHalfLife),
+		AggregateMemoryPeaks: util.NewDecayingHistogram(config.MemoryHistogramOptions, config.MemoryHistogramDecayHalfLife),
+		// TODO: Use individual config for RSS and JVMHeapCommitted.
+		AggregateRSSPeaks:              util.NewDecayingHistogram(config.MemoryHistogramOptions, config.MemoryHistogramDecayHalfLife),
+		AggregateJVMHeapCommittedPeaks: util.NewDecayingHistogram(config.MemoryHistogramOptions, config.MemoryHistogramDecayHalfLife),
+		CreationTime:                   time.Now(),
 	}
 }
 
@@ -197,9 +198,9 @@ func (a *AggregateContainerState) AddSample(sample *ContainerUsageSample) {
 	case ResourceMemory:
 		a.AggregateMemoryPeaks.AddSample(BytesFromMemoryAmount(sample.Usage), 1.0, sample.MeasureStart)
 	case ResourceRSS:
-		a.addRSSSample(sample)
+		a.AggregateRSSPeaks.AddSample(BytesFromMemoryAmount(sample.Usage), 1.0, sample.MeasureStart)
 	case ResourceJVMHeapCommitted:
-		a.addJVMHeapCommittedSample(sample)
+		a.AggregateJVMHeapCommittedPeaks.AddSample(BytesFromMemoryAmount(sample.Usage), 1.0, sample.MeasureStart)
 	default:
 		panic(fmt.Sprintf("AddSample doesn't support resource '%s'", sample.Resource))
 	}
@@ -214,6 +215,10 @@ func (a *AggregateContainerState) SubtractSample(sample *ContainerUsageSample) {
 	switch sample.Resource {
 	case ResourceMemory:
 		a.AggregateMemoryPeaks.SubtractSample(BytesFromMemoryAmount(sample.Usage), 1.0, sample.MeasureStart)
+	case ResourceRSS:
+		a.AggregateRSSPeaks.SubtractSample(BytesFromMemoryAmount(sample.Usage), 1.0, sample.MeasureStart)
+	case ResourceJVMHeapCommitted:
+		a.AggregateJVMHeapCommittedPeaks.SubtractSample(BytesFromMemoryAmount(sample.Usage), 1.0, sample.MeasureStart)
 	default:
 		panic(fmt.Sprintf("SubtractSample doesn't support resource '%s'", sample.Resource))
 	}
@@ -236,32 +241,6 @@ func (a *AggregateContainerState) addCPUSample(sample *ContainerUsageSample) {
 	a.TotalSamplesCount++
 }
 
-func (a *AggregateContainerState) addRSSSample(sample *ContainerUsageSample) {
-	// RSSBytes is the max 5m-average RSS observed of all RSS samples (naive implementation).
-	// TODO: Aggregate properly with histogram once VPACheckpoint updated to support additional histogram.
-	a.RSSBytes = math.Max(a.RSSBytes, BytesFromMemoryAmount(sample.Usage))
-	if sample.MeasureStart.After(a.LastSampleStart) {
-		a.LastSampleStart = sample.MeasureStart
-	}
-	if a.FirstSampleStart.IsZero() || sample.MeasureStart.Before(a.FirstSampleStart) {
-		a.FirstSampleStart = sample.MeasureStart
-	}
-	a.TotalSamplesCount++
-}
-
-func (a *AggregateContainerState) addJVMHeapCommittedSample(sample *ContainerUsageSample) {
-	// JVMHeapCommittedBytes is the max 5m-average committed JVM Heap observed of all JVM Heap samples (naive implementation).
-	// TODO: Aggregate properly with histogram once VPACheckpoint updated to support additional histogram.
-	a.JVMHeapCommittedBytes = math.Max(a.JVMHeapCommittedBytes, BytesFromMemoryAmount(sample.Usage))
-	if sample.MeasureStart.After(a.LastSampleStart) {
-		a.LastSampleStart = sample.MeasureStart
-	}
-	if a.FirstSampleStart.IsZero() || sample.MeasureStart.Before(a.FirstSampleStart) {
-		a.FirstSampleStart = sample.MeasureStart
-	}
-	a.TotalSamplesCount++
-}
-
 // SaveToCheckpoint serializes AggregateContainerState as VerticalPodAutoscalerCheckpointStatus.
 // The serialization may result in loss of precission of the histograms.
 func (a *AggregateContainerState) SaveToCheckpoint() (*vpa_types.VerticalPodAutoscalerCheckpointStatus, error) {
@@ -273,14 +252,24 @@ func (a *AggregateContainerState) SaveToCheckpoint() (*vpa_types.VerticalPodAuto
 	if err != nil {
 		return nil, err
 	}
+	rss, err := a.AggregateRSSPeaks.SaveToChekpoint()
+	if err != nil {
+		return nil, err
+	}
+	jvmHeapCommitted, err := a.AggregateJVMHeapCommittedPeaks.SaveToChekpoint()
+	if err != nil {
+		return nil, err
+	}
 	return &vpa_types.VerticalPodAutoscalerCheckpointStatus{
-		LastUpdateTime:    metav1.NewTime(time.Now()),
-		FirstSampleStart:  metav1.NewTime(a.FirstSampleStart),
-		LastSampleStart:   metav1.NewTime(a.LastSampleStart),
-		TotalSamplesCount: a.TotalSamplesCount,
-		MemoryHistogram:   *memory,
-		CPUHistogram:      *cpu,
-		Version:           SupportedCheckpointVersion,
+		LastUpdateTime:            metav1.NewTime(time.Now()),
+		FirstSampleStart:          metav1.NewTime(a.FirstSampleStart),
+		LastSampleStart:           metav1.NewTime(a.LastSampleStart),
+		TotalSamplesCount:         a.TotalSamplesCount,
+		MemoryHistogram:           *memory,
+		CPUHistogram:              *cpu,
+		RSSHistogram:              *rss,
+		JVMHeapCommittedHistogram: *jvmHeapCommitted,
+		Version:                   SupportedCheckpointVersion,
 	}, nil
 }
 
@@ -298,6 +287,14 @@ func (a *AggregateContainerState) LoadFromCheckpoint(checkpoint *vpa_types.Verti
 		return err
 	}
 	err = a.AggregateCPUUsage.LoadFromCheckpoint(&checkpoint.CPUHistogram)
+	if err != nil {
+		return err
+	}
+	err = a.AggregateRSSPeaks.LoadFromCheckpoint(&checkpoint.RSSHistogram)
+	if err != nil {
+		return err
+	}
+	err = a.AggregateJVMHeapCommittedPeaks.LoadFromCheckpoint(&checkpoint.JVMHeapCommittedHistogram)
 	if err != nil {
 		return err
 	}

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state_test.go
@@ -119,8 +119,8 @@ func TestAggregateStateByContainerName(t *testing.T) {
 	actualCPUHistogram := aggregateResources["app-A"].AggregateCPUUsage
 
 	expectedMemoryHistogram := util.NewDecayingHistogram(config.MemoryHistogramOptions, config.MemoryHistogramDecayHalfLife)
-	expectedMemoryHistogram.AddSample(2e9, 1.0, cluster.GetContainer(containers[0]).WindowEnd)
-	expectedMemoryHistogram.AddSample(4e9, 1.0, cluster.GetContainer(containers[2]).WindowEnd)
+	expectedMemoryHistogram.AddSample(2e9, 1.0, cluster.GetContainer(containers[0]).MemoryWindowEnd)
+	expectedMemoryHistogram.AddSample(4e9, 1.0, cluster.GetContainer(containers[2]).MemoryWindowEnd)
 	actualMemoryHistogram := aggregateResources["app-A"].AggregateMemoryPeaks
 
 	assert.True(t, expectedCPUHistogram.Equals(actualCPUHistogram), "Expected:\n%s\nActual:\n%s", expectedCPUHistogram, actualCPUHistogram)

--- a/vertical-pod-autoscaler/pkg/recommender/model/container.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/container.go
@@ -220,9 +220,6 @@ func (container *ContainerState) addRSSSample(sample *ContainerUsageSample, isOO
 	}
 	container.lastRSSSampleStart = ts
 	if container.RSSWindowEnd.IsZero() { // This is the first sample.
-		if container.Namespace == "vpa-test-service" {
-			klog.Info("first sample for vpa-test-service")
-		}
 		container.RSSWindowEnd = ts
 	}
 


### PR DESCRIPTION
Replaces the naive `max` recommendation implementations for RSS (https://github.com/jodzga/autoscaler/pull/8) and committed JVM heap (https://github.com/jodzga/autoscaler/pull/9) with the same histogram-based recommendation strategy as the native `memory` recommendation. Essentially, every aggregation interval, we will collect the 1 peak value and add it to the histogram.

Note that we ignore OOMKills and use the same opts as memory (e.g. aggregation interval, count, and percentile) for now.