### PR TITLE
Add quality metrics for RSS and committed JVM heap resources

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/model/container.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/container.go
@@ -103,7 +103,6 @@ func (container *ContainerState) addCPUSample(sample *ContainerUsageSample) bool
 	return true
 }
 
-// TODO: Add quality metrics for RSS and JVMHeapCommitted.
 func (container *ContainerState) observeQualityMetrics(usage ResourceAmount, isOOM bool, resource corev1.ResourceName) {
 	if !container.aggregator.NeedsRecommendation() {
 		return
@@ -114,6 +113,10 @@ func (container *ContainerState) observeQualityMetrics(usage ResourceAmount, isO
 	case corev1.ResourceCPU:
 		usageValue = CoresFromCPUAmount(usage)
 	case corev1.ResourceMemory:
+		usageValue = BytesFromMemoryAmount(usage)
+	case corev1.ResourceName(model.ResourceRSS):
+		usageValue = BytesFromMemoryAmount(usage)
+	case corev1.ResourceName(model.ResourceJVMHeapCommitted):
 		usageValue = BytesFromMemoryAmount(usage)
 	}
 	if container.aggregator.GetLastRecommendation() == nil {
@@ -130,6 +133,10 @@ func (container *ContainerState) observeQualityMetrics(usage ResourceAmount, isO
 	case corev1.ResourceCPU:
 		recommendationValue = float64(recommendation.MilliValue()) / 1000.0
 	case corev1.ResourceMemory:
+		recommendationValue = float64(recommendation.Value())
+	case corev1.ResourceName(model.ResourceRSS):
+		recommendationValue = float64(recommendation.Value())
+	case corev1.ResourceName(model.ResourceJVMHeapCommitted):
 		recommendationValue = float64(recommendation.Value())
 	default:
 		klog.Warningf("Unknown resource: %v", resource)

--- a/vertical-pod-autoscaler/pkg/recommender/model/container.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/container.go
@@ -256,7 +256,8 @@ func (container *ContainerState) addRSSSample(sample *ContainerUsageSample, isOO
 		container.rssPeak = 0
 		addNewPeak = true
 	}
-	// TODO: Observe quality metrics once OOM is considered.
+	// TODO: Consider OOM.
+	container.observeQualityMetrics(sample.Usage, false, corev1.ResourceName(ResourceRSS))
 	if addNewPeak {
 		newPeak := ContainerUsageSample{
 			MeasureStart: container.RSSWindowEnd,
@@ -306,7 +307,8 @@ func (container *ContainerState) addJVMHeapCommittedSample(sample *ContainerUsag
 		container.jvmHeapCommittedPeak = 0
 		addNewPeak = true
 	}
-	// TODO: Observe quality metrics once OOM is considered.
+	// TODO: Consider OOM.
+	container.observeQualityMetrics(sample.Usage, false, corev1.ResourceName(ResourceJVMHeapCommitted))
 	if addNewPeak {
 		newPeak := ContainerUsageSample{
 			MeasureStart: container.JVMHeapCommittedWindowEnd,

--- a/vertical-pod-autoscaler/pkg/recommender/model/container.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/container.go
@@ -114,9 +114,9 @@ func (container *ContainerState) observeQualityMetrics(usage ResourceAmount, isO
 		usageValue = CoresFromCPUAmount(usage)
 	case corev1.ResourceMemory:
 		usageValue = BytesFromMemoryAmount(usage)
-	case corev1.ResourceName(model.ResourceRSS):
+	case corev1.ResourceName(ResourceRSS):
 		usageValue = BytesFromMemoryAmount(usage)
-	case corev1.ResourceName(model.ResourceJVMHeapCommitted):
+	case corev1.ResourceName(ResourceJVMHeapCommitted):
 		usageValue = BytesFromMemoryAmount(usage)
 	}
 	if container.aggregator.GetLastRecommendation() == nil {
@@ -134,9 +134,9 @@ func (container *ContainerState) observeQualityMetrics(usage ResourceAmount, isO
 		recommendationValue = float64(recommendation.MilliValue()) / 1000.0
 	case corev1.ResourceMemory:
 		recommendationValue = float64(recommendation.Value())
-	case corev1.ResourceName(model.ResourceRSS):
+	case corev1.ResourceName(ResourceRSS):
 		recommendationValue = float64(recommendation.Value())
-	case corev1.ResourceName(model.ResourceJVMHeapCommitted):
+	case corev1.ResourceName(ResourceJVMHeapCommitted):
 		recommendationValue = float64(recommendation.Value())
 	default:
 		klog.Warningf("Unknown resource: %v", resource)

--- a/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
@@ -19,7 +19,7 @@ package model
 import (
 	"sort"
 	"time"
-	"k8s.io/klog/v2"
+
 	autoscaling "k8s.io/api/autoscaling/v1"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -165,7 +165,6 @@ func (vpa *Vpa) UpdateRecommendation(recommendation *vpa_types.RecommendedPodRes
 	for _, containerRecommendation := range recommendation.ContainerRecommendations {
 		for container, state := range vpa.aggregateContainerStates {
 			if container.ContainerName() == containerRecommendation.ContainerName {
-				klog.InfoS("last recommendation", "lastRecommendation", state.LastRecommendation, "newRecommendation", containerRecommendation.UncappedTarget, "container", container.ContainerName(), "vpa", vpa.ID)
 				metrics_quality.ObserveRecommendationChange(state.LastRecommendation, containerRecommendation.UncappedTarget, vpa.UpdateMode, vpa.PodCount)
 				state.LastRecommendation = containerRecommendation.UncappedTarget
 			}

--- a/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
@@ -19,7 +19,7 @@ package model
 import (
 	"sort"
 	"time"
-
+	"k8s.io/klog/v2"
 	autoscaling "k8s.io/api/autoscaling/v1"
 	apiv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -165,6 +165,7 @@ func (vpa *Vpa) UpdateRecommendation(recommendation *vpa_types.RecommendedPodRes
 	for _, containerRecommendation := range recommendation.ContainerRecommendations {
 		for container, state := range vpa.aggregateContainerStates {
 			if container.ContainerName() == containerRecommendation.ContainerName {
+				klog.InfoS("last recommendation", "lastRecommendation", state.LastRecommendation, "newRecommendation", containerRecommendation.UncappedTarget, "container", container.ContainerName(), "vpa", vpa.ID)
 				metrics_quality.ObserveRecommendationChange(state.LastRecommendation, containerRecommendation.UncappedTarget, vpa.UpdateMode, vpa.PodCount)
 				state.LastRecommendation = containerRecommendation.UncappedTarget
 			}


### PR DESCRIPTION
Adds quality metrics for RSS and committed JVM heap resources, so they will stop emitting that the resources are unknown (i.e. `Unknown resource: <>`).
Note that there are some remaining noise of `Cannot compare as old recommendation for <> is 0.` logs if pods that have been stuck in crashloop for the lifetime of the associated VPA objects.

![Screenshot 2024-05-23 at 2 31 26 PM](https://github.com/jodzga/autoscaler/assets/52840591/3b853dfc-0ada-4360-9326-18b93229bfd2)
