### PR TITLE
Use prometheus client to query custom metrics

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_custom_lister.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_custom_lister.go
@@ -162,17 +162,14 @@ func (c *customPodMetricsLister) query(query nsQuery) nsQueryResult {
 		return nsQueryResult{nsQuery: query, err: err}
 	}
 
-	if res.Type() != prommodel.ValMatrix {
+	if res.Type() != prommodel.ValVector {
 		fmt.Println(res.Type())
 		return nsQueryResult{nsQuery: query, err: fmt.Errorf("unexpected response type %s", res.Type())}
 	}
 
-	response := res.(prommodel.Matrix)
-	for _, stream := range response {
-		fmt.Println(stream)
-		for _, sample := range stream.Values {
-			fmt.Printf("  Value: %v, Timestamp: %v, Whole: %v\n", sample.Value, sample.Timestamp, sample)
-		}
+	response := res.(prommodel.Vector)
+	for _, sample := range response {
+		fmt.Printf("  Value: %v, Timestamp: %v, Whole: %v\n", sample.Value, sample.Timestamp, sample)
 	}
 
 	return nsQueryResult{nsQuery: query, err: fmt.Errorf("hello %s", res.Type())}

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_custom_lister.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_custom_lister.go
@@ -186,7 +186,7 @@ func (c *customPodMetricsLister) query(ctx context.Context, query nsQuery) nsQue
 		value := sample.Value.String()
 		resourceQuantity, err := resource.ParseQuantity(value)
 		if err != nil {
-			klog.ErrorS(fmt.Errorf("Not found"), "Failed to get value as resource quantity string", "value", value)
+			klog.ErrorS(err, "Failed to parse resource quantity", "value", value, "resource", query.resource, "namespace", query.namespace, "pod", podName, "container", containerName)
 			continue
 		}
 

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_custom_lister.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_custom_lister.go
@@ -149,11 +149,7 @@ func (c *customPodMetricsLister) List(ctx context.Context, namespace string, opt
 		}
 	}
 
-	fmt.Printf("podsCustomMetrics: %+v\n", podsCustomMetrics)
-
-	return nil, nil
-
-	// return podsCustomMetrics, nil
+	return podsCustomMetrics, nil
 }
 
 // query queries M3 for the specified custom resource metric and returns the result.

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_custom_lister.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_custom_lister.go
@@ -45,7 +45,7 @@ type customPodMetricsLister struct {
 // containerUsages maps containers to their resource usages.
 type containerUsages map[string]resource.Quantity
 
-// nsQueryResult holds the parsed result (from nsQueryResponse) of a custom resource query for a namespace.
+// nsQueryResult holds the parsed result of a custom resource query for a namespace.
 type nsQueryResult struct {
 	// Maps pods to their containers' resource usages.
 	podUsages map[string]containerUsages
@@ -53,7 +53,7 @@ type nsQueryResult struct {
 	err       error
 }
 
-// TODO(leekathy): Replace with the prom client and add unit tests.
+// TODO(leekathy): Add unit tests.
 func newCustomPodMetricsLister(promClient prometheusv1.API, queries []nsQueryBuilder, podLister v1lister.PodLister) PodMetricsLister {
 	return &customPodMetricsLister{
 		client:    promClient,
@@ -158,10 +158,12 @@ func (c *customPodMetricsLister) List(ctx context.Context, namespace string, opt
 func (c *customPodMetricsLister) query(query nsQuery) nsQueryResult {
 	res, _, err := c.client.Query(context.Background(), query.query, time.Now())
 	if err != nil {
+		fmt.Println(err)
 		return nsQueryResult{nsQuery: query, err: err}
 	}
 
 	if res.Type() != prommodel.ValMatrix {
+		fmt.Println(res.Type())
 		return nsQueryResult{nsQuery: query, err: fmt.Errorf("unexpected response type %s", res.Type())}
 	}
 

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_custom_query_builder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_custom_query_builder.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"strings"
 
+	prommodel "github.com/prometheus/common/model"
+
 	k8sapiv1 "k8s.io/api/core/v1"
 	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
 )
@@ -38,8 +40,8 @@ type nsQuery struct {
 	resource           k8sapiv1.ResourceName
 	pods               podsBatch
 	namespace          string
-	containerNameLabel string
-	podNameLabel       string
+	containerNameLabel prommodel.LabelName
+	podNameLabel       prommodel.LabelName
 }
 
 // nsQueryBuilder is an interface for building a custom resource query.
@@ -53,22 +55,22 @@ type nsQueryBuilder interface {
 // rssQueryBuilder implements the nsQueryBuilder interface for the RSS metric.
 type rssQueryBuilder struct {
 	resource           k8sapiv1.ResourceName
-	containerNameLabel string
-	podNameLabel       string
+	containerNameLabel prommodel.LabelName
+	podNameLabel       prommodel.LabelName
 }
 
 // jvmHeapCommittedQueryBuilder implements the nsQueryBuilder interface for the JVM Heap Committed metric.
 type jvmHeapCommittedQueryBuilder struct {
 	resource           k8sapiv1.ResourceName
-	containerNameLabel string
-	podNameLabel       string
+	containerNameLabel prommodel.LabelName
+	podNameLabel       prommodel.LabelName
 }
 
 func regexOr(values []string) string {
 	return strings.Join(values, "|")
 }
 
-func getRSSQuery(containerNameLabel string, podNameLabel string) nsQueryBuilder {
+func getRSSQuery(containerNameLabel prommodel.LabelName, podNameLabel prommodel.LabelName) nsQueryBuilder {
 	return &rssQueryBuilder{
 		resource:           k8sapiv1.ResourceName(model.ResourceRSS),
 		containerNameLabel: containerNameLabel,
@@ -76,7 +78,7 @@ func getRSSQuery(containerNameLabel string, podNameLabel string) nsQueryBuilder 
 	}
 }
 
-func getJVMHeapCommittedQuery(containerNameLabel string, podNameLabel string) nsQueryBuilder {
+func getJVMHeapCommittedQuery(containerNameLabel prommodel.LabelName, podNameLabel prommodel.LabelName) nsQueryBuilder {
 	return &jvmHeapCommittedQueryBuilder{
 		resource:           k8sapiv1.ResourceName(model.ResourceJVMHeapCommitted),
 		containerNameLabel: containerNameLabel,

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
@@ -23,6 +23,7 @@ import (
 
 	promapi "github.com/prometheus/client_golang/api"
 	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	prommodel "github.com/prometheus/common/model"
 
 	k8sapiv1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -50,8 +51,8 @@ type podMetricsSource struct {
 
 // customQueries holds the custom resource query builders.
 var customQueries = []nsQueryBuilder{
-	getRSSQuery("container_name", "pod_name"),
-	getJVMHeapCommittedQuery("kubernetes_container_name", "kubernetes_pod_name"),
+	getRSSQuery(prommodel.LabelName("container_name"), prommodel.LabelName("pod_name")),
+	getJVMHeapCommittedQuery(prommodel.LabelName("kubernetes_container_name"), prommodel.LabelName("kubernetes_pod_name")),
 }
 
 // NewPodMetricsesSource Returns a Source-wrapper around PodMetricsesGetter.

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
@@ -71,7 +71,7 @@ func NewPodMetricsesSource(source resourceclient.PodMetricsesGetter, podLister v
 		Address: m3Url,
 	})
 	if err != nil {
-		klog.Infof("Failed to initialize M3 client: %v", err)
+		klog.Infof("Failed to initialize M3 client - skipping pod custom resource usage metrics: %v", err)
 		return podMetricsSource{
 			metricsGetter:       source,
 			customMetricsLister: nil,


### PR DESCRIPTION
Uses the prom client to avoid expensive JSON unmarshaling of the raw M3 responses for custom resource usage metrics. This halves the latency for the `LoadMetrics` step in large clusters.

Sets a timeout of 45s for the queries in order to avoid increasing the overall execution latency >> 1m.