### PR TITLE
Binary decaying histogram.

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
+++ b/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
@@ -147,10 +147,4 @@ func subtractCurrentContainerMemoryPeak(a *model.AggregateContainerState, contai
 	if now.Before(container.MemoryWindowEnd) {
 		a.AggregateMemoryPeaks.SubtractSample(model.BytesFromMemoryAmount(container.GetMaxMemoryPeak()), 1.0, container.MemoryWindowEnd)
 	}
-	if now.Before(container.RSSWindowEnd) {
-		a.AggregateRSSPeaks.SubtractSample(model.BytesFromMemoryAmount(container.GetMaxRSSPeak()), 1.0, container.RSSWindowEnd)
-	}
-	if now.Before(container.JVMHeapCommittedWindowEnd) {
-		a.AggregateJVMHeapCommittedPeaks.SubtractSample(model.BytesFromMemoryAmount(container.GetMaxJVMHeapCommittedPeak()), 1.0, container.JVMHeapCommittedWindowEnd)
-	}
 }

--- a/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
+++ b/vertical-pod-autoscaler/pkg/recommender/checkpoint/checkpoint_writer.go
@@ -146,5 +146,6 @@ func buildAggregateContainerStateMap(vpa *model.Vpa, cluster *model.ClusterState
 func subtractCurrentContainerMemoryPeak(a *model.AggregateContainerState, container *model.ContainerState, now time.Time) {
 	if now.Before(container.MemoryWindowEnd) {
 		a.AggregateMemoryPeaks.SubtractSample(model.BytesFromMemoryAmount(container.GetMaxMemoryPeak()), 1.0, container.MemoryWindowEnd)
+		// We don't subtract sample from the RSS and JVMHeapCommitted histograms as they use custom binary decaying histogram.
 	}
 }

--- a/vertical-pod-autoscaler/pkg/recommender/logic/estimator.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/estimator.go
@@ -100,8 +100,7 @@ func (e *percentileEstimator) GetResourceEstimation(s *model.AggregateContainerS
 			s.AggregateCPUUsage.Percentile(e.cpuPercentile)),
 		model.ResourceMemory: model.MemoryAmountFromBytes(
 			s.AggregateMemoryPeaks.Percentile(e.memoryPercentile)),
-		model.ResourceRSS:              model.MemoryAmountFromBytes(s.AggregateRSSPeaks.Percentile(1.0)),
-		model.ResourceJVMHeapCommitted: model.MemoryAmountFromBytes(s.AggregateJVMHeapCommittedPeaks.Percentile(1.0)),
+		model.ResourceRSS: model.MemoryAmountFromBytes(s.AggregateRSSPeaks.Percentile(1.0)),
 	}
 	if !s.AggregateJVMHeapCommittedPeaks.IsEmpty() {
 		resourceEstimations[model.ResourceJVMHeapCommitted] = model.MemoryAmountFromBytes(s.AggregateJVMHeapCommittedPeaks.Percentile(1.0))

--- a/vertical-pod-autoscaler/pkg/recommender/logic/estimator.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/estimator.go
@@ -95,15 +95,18 @@ func (e *constEstimator) GetResourceEstimation(s *model.AggregateContainerState)
 
 // Returns specific percentiles of CPU and memory peaks distributions.
 func (e *percentileEstimator) GetResourceEstimation(s *model.AggregateContainerState) model.Resources {
-	return model.Resources{
+	resourceEstimations := model.Resources{
 		model.ResourceCPU: model.CPUAmountFromCores(
 			s.AggregateCPUUsage.Percentile(e.cpuPercentile)),
 		model.ResourceMemory: model.MemoryAmountFromBytes(
 			s.AggregateMemoryPeaks.Percentile(e.memoryPercentile)),
-		// TODO: Use individual config for RSS and JVMHeapCommitted.
 		model.ResourceRSS:              model.MemoryAmountFromBytes(s.AggregateRSSPeaks.Percentile(1.0)),
 		model.ResourceJVMHeapCommitted: model.MemoryAmountFromBytes(s.AggregateJVMHeapCommittedPeaks.Percentile(1.0)),
 	}
+	if !s.AggregateJVMHeapCommittedPeaks.IsEmpty() {
+		resourceEstimations[model.ResourceJVMHeapCommitted] = model.MemoryAmountFromBytes(s.AggregateJVMHeapCommittedPeaks.Percentile(1.0))
+	}
+	return resourceEstimations
 }
 
 // Returns a non-negative real number that heuristically measures how much

--- a/vertical-pod-autoscaler/pkg/recommender/logic/estimator.go
+++ b/vertical-pod-autoscaler/pkg/recommender/logic/estimator.go
@@ -101,8 +101,8 @@ func (e *percentileEstimator) GetResourceEstimation(s *model.AggregateContainerS
 		model.ResourceMemory: model.MemoryAmountFromBytes(
 			s.AggregateMemoryPeaks.Percentile(e.memoryPercentile)),
 		// TODO: Use individual config for RSS and JVMHeapCommitted.
-		model.ResourceRSS:              model.MemoryAmountFromBytes(s.AggregateRSSPeaks.Percentile(e.memoryPercentile)),
-		model.ResourceJVMHeapCommitted: model.MemoryAmountFromBytes(s.AggregateJVMHeapCommittedPeaks.Percentile(e.memoryPercentile)),
+		model.ResourceRSS:              model.MemoryAmountFromBytes(s.AggregateRSSPeaks.Percentile(1.0)),
+		model.ResourceJVMHeapCommitted: model.MemoryAmountFromBytes(s.AggregateJVMHeapCommittedPeaks.Percentile(1.0)),
 	}
 }
 

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -19,8 +19,9 @@ package main
 import (
 	"context"
 	"flag"
-	resourceclient "k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1"
 	"time"
+
+	resourceclient "k8s.io/metrics/pkg/client/clientset/versioned/typed/metrics/v1beta1"
 
 	apiv1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/informers"
@@ -86,6 +87,7 @@ var (
 	cpuHistogramDecayHalfLife      = flag.Duration("cpu-histogram-decay-half-life", model.DefaultCPUHistogramDecayHalfLife, `The amount of time it takes a historical CPU usage sample to lose half of its weight.`)
 	oomBumpUpRatio                 = flag.Float64("oom-bump-up-ratio", model.DefaultOOMBumpUpRatio, `The memory bump up ratio when OOM occurred, default is 1.2.`)
 	oomMinBumpUp                   = flag.Float64("oom-min-bump-up-bytes", model.DefaultOOMMinBumpUp, `The minimal increase of memory when OOM occurred in bytes, default is 100 * 1024 * 1024`)
+	memoryHistogramRetentionDays   = flag.Int("memory-histogram-retention-days", model.DefaultMemoryHistogramRetentionDays, `The number of days to retain memory peak in histogram.`)
 )
 
 // Post processors flags
@@ -116,7 +118,7 @@ func main() {
 	controllerFetcher := controllerfetcher.NewControllerFetcher(config, kubeClient, factory, scaleCacheEntryFreshnessTime, scaleCacheEntryLifetime, scaleCacheEntryJitterFactor)
 	podLister, oomObserver := input.NewPodListerAndOOMObserver(kubeClient, *vpaObjectNamespace)
 
-	model.InitializeAggregationsConfig(model.NewAggregationsConfig(*memoryAggregationInterval, *memoryAggregationIntervalCount, *memoryHistogramDecayHalfLife, *cpuHistogramDecayHalfLife, *oomBumpUpRatio, *oomMinBumpUp))
+	model.InitializeAggregationsConfig(model.NewAggregationsConfig(*memoryAggregationInterval, *memoryAggregationIntervalCount, *memoryHistogramDecayHalfLife, *cpuHistogramDecayHalfLife, *oomBumpUpRatio, *oomMinBumpUp, *memoryHistogramRetentionDays))
 
 	healthCheck := metrics.NewHealthCheck(*metricsFetcherInterval*5, true)
 	metrics.Initialize(*address, healthCheck)

--- a/vertical-pod-autoscaler/pkg/recommender/main.go
+++ b/vertical-pod-autoscaler/pkg/recommender/main.go
@@ -81,13 +81,13 @@ var (
 
 // Aggregation configuration flags
 var (
-	memoryAggregationInterval      = flag.Duration("memory-aggregation-interval", model.DefaultMemoryAggregationInterval, `The length of a single interval, for which the peak memory usage is computed. Memory usage peaks are aggregated in multiples of this interval. In other words there is one memory usage sample per interval (the maximum usage over that interval)`)
-	memoryAggregationIntervalCount = flag.Int64("memory-aggregation-interval-count", model.DefaultMemoryAggregationIntervalCount, `The number of consecutive memory-aggregation-intervals which make up the MemoryAggregationWindowLength which in turn is the period for memory usage aggregation by VPA. In other words, MemoryAggregationWindowLength = memory-aggregation-interval * memory-aggregation-interval-count.`)
-	memoryHistogramDecayHalfLife   = flag.Duration("memory-histogram-decay-half-life", model.DefaultMemoryHistogramDecayHalfLife, `The amount of time it takes a historical memory usage sample to lose half of its weight. In other words, a fresh usage sample is twice as 'important' as one with age equal to the half life period.`)
-	cpuHistogramDecayHalfLife      = flag.Duration("cpu-histogram-decay-half-life", model.DefaultCPUHistogramDecayHalfLife, `The amount of time it takes a historical CPU usage sample to lose half of its weight.`)
-	oomBumpUpRatio                 = flag.Float64("oom-bump-up-ratio", model.DefaultOOMBumpUpRatio, `The memory bump up ratio when OOM occurred, default is 1.2.`)
-	oomMinBumpUp                   = flag.Float64("oom-min-bump-up-bytes", model.DefaultOOMMinBumpUp, `The minimal increase of memory when OOM occurred in bytes, default is 100 * 1024 * 1024`)
-	memoryHistogramRetentionDays   = flag.Int("memory-histogram-retention-days", model.DefaultMemoryHistogramRetentionDays, `The number of days to retain memory peak in histogram.`)
+	memoryAggregationInterval          = flag.Duration("memory-aggregation-interval", model.DefaultMemoryAggregationInterval, `The length of a single interval, for which the peak memory usage is computed. Memory usage peaks are aggregated in multiples of this interval. In other words there is one memory usage sample per interval (the maximum usage over that interval)`)
+	memoryAggregationIntervalCount     = flag.Int64("memory-aggregation-interval-count", model.DefaultMemoryAggregationIntervalCount, `The number of consecutive memory-aggregation-intervals which make up the MemoryAggregationWindowLength which in turn is the period for memory usage aggregation by VPA. In other words, MemoryAggregationWindowLength = memory-aggregation-interval * memory-aggregation-interval-count.`)
+	memoryHistogramDecayHalfLife       = flag.Duration("memory-histogram-decay-half-life", model.DefaultMemoryHistogramDecayHalfLife, `The amount of time it takes a historical memory usage sample to lose half of its weight. In other words, a fresh usage sample is twice as 'important' as one with age equal to the half life period.`)
+	cpuHistogramDecayHalfLife          = flag.Duration("cpu-histogram-decay-half-life", model.DefaultCPUHistogramDecayHalfLife, `The amount of time it takes a historical CPU usage sample to lose half of its weight.`)
+	oomBumpUpRatio                     = flag.Float64("oom-bump-up-ratio", model.DefaultOOMBumpUpRatio, `The memory bump up ratio when OOM occurred, default is 1.2.`)
+	oomMinBumpUp                       = flag.Float64("oom-min-bump-up-bytes", model.DefaultOOMMinBumpUp, `The minimal increase of memory when OOM occurred in bytes, default is 100 * 1024 * 1024`)
+	customMemoryHistogramRetentionDays = flag.Int("custom-memory-histogram-retention-days", model.DefaultCustomMemoryHistogramRetentionDays, `The number of days to retain memory peak in custom binary decaying histogram. This only applies to RSS and JVM Heap Committed memory.`)
 )
 
 // Post processors flags
@@ -118,7 +118,7 @@ func main() {
 	controllerFetcher := controllerfetcher.NewControllerFetcher(config, kubeClient, factory, scaleCacheEntryFreshnessTime, scaleCacheEntryLifetime, scaleCacheEntryJitterFactor)
 	podLister, oomObserver := input.NewPodListerAndOOMObserver(kubeClient, *vpaObjectNamespace)
 
-	model.InitializeAggregationsConfig(model.NewAggregationsConfig(*memoryAggregationInterval, *memoryAggregationIntervalCount, *memoryHistogramDecayHalfLife, *cpuHistogramDecayHalfLife, *oomBumpUpRatio, *oomMinBumpUp, *memoryHistogramRetentionDays))
+	model.InitializeAggregationsConfig(model.NewAggregationsConfig(*memoryAggregationInterval, *memoryAggregationIntervalCount, *memoryHistogramDecayHalfLife, *cpuHistogramDecayHalfLife, *oomBumpUpRatio, *oomMinBumpUp, *customMemoryHistogramRetentionDays))
 
 	healthCheck := metrics.NewHealthCheck(*metricsFetcherInterval*5, true)
 	metrics.Initialize(*address, healthCheck)

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
@@ -96,10 +96,10 @@ type AggregateContainerState struct {
 	// each container should add one peak per memory aggregation interval (e.g. once every 24h).
 	AggregateMemoryPeaks util.Histogram
 	// AggregateRSSPeaks is a distribution of RSS peaks from all containers:
-	// each container should add one peak per memory aggregation interval (e.g. once every 24h).
+	// each container should add one peak per day.
 	AggregateRSSPeaks util.Histogram
 	// AggregateJVMHeapCommittedPeaks is a distribution of committed JVM heap peaks from all containers:
-	// each container should add one peak per memory aggregation interval (e.g. once every 24h).
+	// each container should add one peak per day.
 	AggregateJVMHeapCommittedPeaks util.Histogram
 	// Note: first/last sample timestamps as well as the sample count are based only on CPU samples.
 	FirstSampleStart  time.Time

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
@@ -183,8 +183,8 @@ func NewAggregateContainerState() *AggregateContainerState {
 	return &AggregateContainerState{
 		AggregateCPUUsage:              util.NewDecayingHistogram(config.CPUHistogramOptions, config.CPUHistogramDecayHalfLife),
 		AggregateMemoryPeaks:           util.NewDecayingHistogram(config.MemoryHistogramOptions, config.MemoryHistogramDecayHalfLife),
-		AggregateRSSPeaks:              util.NewBinaryDecayingHistogram(config.MemoryHistogramOptions, config.MemoryHistogramRetentionDays),
-		AggregateJVMHeapCommittedPeaks: util.NewBinaryDecayingHistogram(config.MemoryHistogramOptions, config.MemoryHistogramRetentionDays),
+		AggregateRSSPeaks:              util.NewBinaryDecayingHistogram(config.MemoryHistogramOptions, config.CustomMemoryHistogramRetentionDays),
+		AggregateJVMHeapCommittedPeaks: util.NewBinaryDecayingHistogram(config.MemoryHistogramOptions, config.CustomMemoryHistogramRetentionDays),
 		CreationTime:                   time.Now(),
 	}
 }

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregations_config.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregations_config.go
@@ -56,7 +56,7 @@ type AggregationsConfig struct {
 	// OOMMinBumpUp specifies the minimal increase of memory when OOM occurred in bytes.
 	OOMMinBumpUp float64
 	// Number of days to retain memory peaks in the history.
-	MemoryHistogramRetentionDays int
+	CustomMemoryHistogramRetentionDays int
 }
 
 const (
@@ -81,8 +81,8 @@ const (
 	DefaultOOMBumpUpRatio float64 = 1.2 // Memory is increased by 20% after an OOMKill.
 	// DefaultOOMMinBumpUp is the default value for OOMMinBumpUp.
 	DefaultOOMMinBumpUp float64 = 100 * 1024 * 1024 // Memory is increased by at least 100MB after an OOMKill.
-	// DefaultMemoryHistogramRetentionDays is the default value for MemoryHistogramRetentionDays.
-	DefaultMemoryHistogramRetentionDays int = 90
+	// DefaultCustomMemoryHistogramRetentionDays is the default value for CustomMemoryHistogramRetentionDays.
+	DefaultCustomMemoryHistogramRetentionDays int = 90
 )
 
 // GetMemoryAggregationWindowLength returns the total length of the memory usage history aggregated by VPA.
@@ -115,16 +115,16 @@ func (a *AggregationsConfig) memoryHistogramOptions() util.HistogramOptions {
 }
 
 // NewAggregationsConfig creates a new AggregationsConfig based on the supplied parameters and default values.
-func NewAggregationsConfig(memoryAggregationInterval time.Duration, memoryAggregationIntervalCount int64, memoryHistogramDecayHalfLife, cpuHistogramDecayHalfLife time.Duration, oomBumpUpRatio float64, oomMinBumpUp float64, memoryHistogramRetentionDays int) *AggregationsConfig {
+func NewAggregationsConfig(memoryAggregationInterval time.Duration, memoryAggregationIntervalCount int64, memoryHistogramDecayHalfLife, cpuHistogramDecayHalfLife time.Duration, oomBumpUpRatio float64, oomMinBumpUp float64, customMemoryHistogramRetentionDays int) *AggregationsConfig {
 	a := &AggregationsConfig{
-		MemoryAggregationInterval:      memoryAggregationInterval,
-		MemoryAggregationIntervalCount: memoryAggregationIntervalCount,
-		HistogramBucketSizeGrowth:      DefaultHistogramBucketSizeGrowth,
-		MemoryHistogramDecayHalfLife:   memoryHistogramDecayHalfLife,
-		CPUHistogramDecayHalfLife:      cpuHistogramDecayHalfLife,
-		OOMBumpUpRatio:                 oomBumpUpRatio,
-		OOMMinBumpUp:                   oomMinBumpUp,
-		MemoryHistogramRetentionDays:   memoryHistogramRetentionDays,
+		MemoryAggregationInterval:          memoryAggregationInterval,
+		MemoryAggregationIntervalCount:     memoryAggregationIntervalCount,
+		HistogramBucketSizeGrowth:          DefaultHistogramBucketSizeGrowth,
+		MemoryHistogramDecayHalfLife:       memoryHistogramDecayHalfLife,
+		CPUHistogramDecayHalfLife:          cpuHistogramDecayHalfLife,
+		OOMBumpUpRatio:                     oomBumpUpRatio,
+		OOMMinBumpUp:                       oomMinBumpUp,
+		CustomMemoryHistogramRetentionDays: customMemoryHistogramRetentionDays,
 	}
 	a.CPUHistogramOptions = a.cpuHistogramOptions()
 	a.MemoryHistogramOptions = a.memoryHistogramOptions()
@@ -136,7 +136,7 @@ var aggregationsConfig *AggregationsConfig
 // GetAggregationsConfig gets the aggregations config. Initializes to default values if not initialized already.
 func GetAggregationsConfig() *AggregationsConfig {
 	if aggregationsConfig == nil {
-		aggregationsConfig = NewAggregationsConfig(DefaultMemoryAggregationInterval, DefaultMemoryAggregationIntervalCount, DefaultMemoryHistogramDecayHalfLife, DefaultCPUHistogramDecayHalfLife, DefaultOOMBumpUpRatio, DefaultOOMMinBumpUp, DefaultMemoryHistogramRetentionDays)
+		aggregationsConfig = NewAggregationsConfig(DefaultMemoryAggregationInterval, DefaultMemoryAggregationIntervalCount, DefaultMemoryHistogramDecayHalfLife, DefaultCPUHistogramDecayHalfLife, DefaultOOMBumpUpRatio, DefaultOOMMinBumpUp, DefaultCustomMemoryHistogramRetentionDays)
 	}
 
 	return aggregationsConfig

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregations_config.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregations_config.go
@@ -55,6 +55,8 @@ type AggregationsConfig struct {
 	OOMBumpUpRatio float64
 	// OOMMinBumpUp specifies the minimal increase of memory when OOM occurred in bytes.
 	OOMMinBumpUp float64
+	// Number of days to retain memory peaks in the history.
+	MemoryHistogramRetentionDays int
 }
 
 const (
@@ -79,6 +81,8 @@ const (
 	DefaultOOMBumpUpRatio float64 = 1.2 // Memory is increased by 20% after an OOMKill.
 	// DefaultOOMMinBumpUp is the default value for OOMMinBumpUp.
 	DefaultOOMMinBumpUp float64 = 100 * 1024 * 1024 // Memory is increased by at least 100MB after an OOMKill.
+	// DefaultMemoryHistogramRetentionDays is the default value for MemoryHistogramRetentionDays.
+	DefaultMemoryHistogramRetentionDays int = 90
 )
 
 // GetMemoryAggregationWindowLength returns the total length of the memory usage history aggregated by VPA.
@@ -111,7 +115,7 @@ func (a *AggregationsConfig) memoryHistogramOptions() util.HistogramOptions {
 }
 
 // NewAggregationsConfig creates a new AggregationsConfig based on the supplied parameters and default values.
-func NewAggregationsConfig(memoryAggregationInterval time.Duration, memoryAggregationIntervalCount int64, memoryHistogramDecayHalfLife, cpuHistogramDecayHalfLife time.Duration, oomBumpUpRatio float64, oomMinBumpUp float64) *AggregationsConfig {
+func NewAggregationsConfig(memoryAggregationInterval time.Duration, memoryAggregationIntervalCount int64, memoryHistogramDecayHalfLife, cpuHistogramDecayHalfLife time.Duration, oomBumpUpRatio float64, oomMinBumpUp float64, memoryHistogramRetentionDays int) *AggregationsConfig {
 	a := &AggregationsConfig{
 		MemoryAggregationInterval:      memoryAggregationInterval,
 		MemoryAggregationIntervalCount: memoryAggregationIntervalCount,
@@ -120,6 +124,7 @@ func NewAggregationsConfig(memoryAggregationInterval time.Duration, memoryAggreg
 		CPUHistogramDecayHalfLife:      cpuHistogramDecayHalfLife,
 		OOMBumpUpRatio:                 oomBumpUpRatio,
 		OOMMinBumpUp:                   oomMinBumpUp,
+		MemoryHistogramRetentionDays:   memoryHistogramRetentionDays,
 	}
 	a.CPUHistogramOptions = a.cpuHistogramOptions()
 	a.MemoryHistogramOptions = a.memoryHistogramOptions()
@@ -131,7 +136,7 @@ var aggregationsConfig *AggregationsConfig
 // GetAggregationsConfig gets the aggregations config. Initializes to default values if not initialized already.
 func GetAggregationsConfig() *AggregationsConfig {
 	if aggregationsConfig == nil {
-		aggregationsConfig = NewAggregationsConfig(DefaultMemoryAggregationInterval, DefaultMemoryAggregationIntervalCount, DefaultMemoryHistogramDecayHalfLife, DefaultCPUHistogramDecayHalfLife, DefaultOOMBumpUpRatio, DefaultOOMMinBumpUp)
+		aggregationsConfig = NewAggregationsConfig(DefaultMemoryAggregationInterval, DefaultMemoryAggregationIntervalCount, DefaultMemoryHistogramDecayHalfLife, DefaultCPUHistogramDecayHalfLife, DefaultOOMBumpUpRatio, DefaultOOMMinBumpUp, DefaultMemoryHistogramRetentionDays)
 	}
 
 	return aggregationsConfig

--- a/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/vpa.go
@@ -165,7 +165,7 @@ func (vpa *Vpa) UpdateRecommendation(recommendation *vpa_types.RecommendedPodRes
 	for _, containerRecommendation := range recommendation.ContainerRecommendations {
 		for container, state := range vpa.aggregateContainerStates {
 			if container.ContainerName() == containerRecommendation.ContainerName {
-				metrics_quality.ObserveRecommendationChange(state.LastRecommendation, containerRecommendation.UncappedTarget, vpa.UpdateMode, vpa.PodCount)
+				metrics_quality.ObserveRecommendationChange(state.LastRecommendation, containerRecommendation.UncappedTarget, vpa.UpdateMode, vpa.PodCount, vpa.ID.Namespace, vpa.ID.VpaName, container.ContainerName())
 				state.LastRecommendation = containerRecommendation.UncappedTarget
 			}
 		}

--- a/vertical-pod-autoscaler/pkg/recommender/util/binary_decaying_histogram.go
+++ b/vertical-pod-autoscaler/pkg/recommender/util/binary_decaying_histogram.go
@@ -1,0 +1,233 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+)
+
+// NewHistogram returns a new Histogram instance using given options.
+func NewBinaryDecayingHistogram(options HistogramOptions, retentionDays int) Histogram {
+	if retentionDays < 3 {
+		panic("at least 3 days retention is required")
+	}
+	return &binaryDecayingHistogram{
+		options:       options,
+		bucketForDay:  make([]uint16, retentionDays),
+		lastDayIndex:  0,
+		retentionDays: retentionDays}
+}
+
+type binaryDecayingHistogram struct {
+	// Bucketing scheme.
+	options HistogramOptions
+	// Index of a bucket for each day. Buckets are indexed starting with 1.
+	bucketForDay []uint16
+	// Last recorded day index.
+	lastDayIndex int
+	// Retention days.
+	retentionDays int
+}
+
+func (h *binaryDecayingHistogram) dayIndex(ts time.Time) int {
+	return int(ts.Unix() / (60 * 60 * 24))
+}
+
+func (h *binaryDecayingHistogram) addSampleToBucket(bucket uint16, dayIndex int) {
+	if h.lastDayIndex > 0 {
+		// Ignore samples from too far in the past
+		if dayIndex <= h.lastDayIndex-h.retentionDays {
+			return
+		}
+		// If dayIndex not in the future, we will set bucket to max of current and new value
+		if dayIndex <= h.lastDayIndex && h.bucketForDay[dayIndex%h.retentionDays] > bucket {
+			bucket = h.bucketForDay[dayIndex%h.retentionDays]
+		}
+		// Move forward if necessary
+		if dayIndex > h.lastDayIndex {
+			i := h.lastDayIndex + 1
+			for i < dayIndex {
+				h.bucketForDay[i%h.retentionDays] = 0
+				// Break if we cleared out all days
+				if i%h.retentionDays == h.lastDayIndex%h.retentionDays {
+					break
+				}
+				i++
+			}
+		}
+	}
+	h.bucketForDay[dayIndex%h.retentionDays] = bucket
+	if dayIndex > h.lastDayIndex {
+		h.lastDayIndex = dayIndex
+	}
+}
+
+func (h *binaryDecayingHistogram) addSample(value float64, dayIndex int) {
+	bucket := h.options.FindBucket(value) + 1
+	h.addSampleToBucket(uint16(bucket), dayIndex)
+}
+
+func (h *binaryDecayingHistogram) AddSample(value float64, weight float64, time time.Time) {
+	dayIndex := h.dayIndex(time)
+	h.addSample(value, dayIndex)
+}
+
+func (h *binaryDecayingHistogram) SubtractSample(value float64, weight float64, time time.Time) {
+	panic("SubtractSample function is not implemented for binary decaying histogram")
+}
+
+func (h *binaryDecayingHistogram) Merge(other Histogram) {
+	o := other.(*binaryDecayingHistogram)
+	if h.options != o.options {
+		panic("can't merge histograms with different options")
+	}
+	if h.retentionDays != o.retentionDays {
+		panic("can't merge histograms with different retention days")
+	}
+	for day := o.lastDayIndex; day > o.lastDayIndex-o.retentionDays && day >= 0; day-- {
+		bucket := o.bucketForDay[day%o.retentionDays]
+		if day <= h.lastDayIndex && day > h.lastDayIndex-h.retentionDays {
+			if h.bucketForDay[day%h.retentionDays] > bucket {
+				bucket = h.bucketForDay[day%h.retentionDays]
+			}
+		}
+		if bucket > 0 {
+			h.addSampleToBucket(bucket, day)
+		}
+	}
+}
+
+func (h *binaryDecayingHistogram) Percentile(percentile float64) float64 {
+	if percentile != 1.0 {
+		panic("Only Percentile(1.0) function is implemented for binary decaying histogram, got: " + fmt.Sprintf("%f", percentile))
+	}
+	maxBucket := uint16(0)
+	for day := 0; day < h.retentionDays; day++ {
+		if h.bucketForDay[day] > maxBucket {
+			maxBucket = h.bucketForDay[day]
+		}
+	}
+	value := 0.0
+	if maxBucket > 0 {
+		value = h.valueForBucket(int(maxBucket) - 1)
+	}
+	return value
+}
+
+func (h *binaryDecayingHistogram) IsEmpty() bool {
+	for day := 0; day < h.retentionDays; day++ {
+		if h.bucketForDay[day] != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func (h *binaryDecayingHistogram) valueForBucket(bucket int) float64 {
+	if bucket < h.options.NumBuckets()-1 {
+		// Return the end of the bucket.
+		return h.options.GetBucketStart(bucket + 1)
+	}
+	// Return the start of the last bucket (note that the last bucket
+	// doesn't have an upper bound).
+	return h.options.GetBucketStart(bucket)
+}
+
+func (h *binaryDecayingHistogram) String() string {
+	lines := []string{
+		fmt.Sprintf("retentionDays: %d", h.retentionDays),
+		"day\tbucket\tvalue",
+	}
+	for day := h.lastDayIndex; day > h.lastDayIndex-h.retentionDays && day >= 0; day-- {
+		bucket := h.bucketForDay[day%h.retentionDays]
+		value := 0.0
+		if bucket > 0 {
+			value = h.valueForBucket(int(bucket) - 1)
+		}
+		lines = append(lines, fmt.Sprintf("%d\t%d\t%.3f", day, bucket, value))
+	}
+	lines = append(lines, "\n")
+	return strings.Join(lines, "\n")
+}
+
+func (h *binaryDecayingHistogram) Equals(other Histogram) bool {
+	h2, typesMatch := other.(*binaryDecayingHistogram)
+	if !typesMatch || h.options != h2.options || h.retentionDays != h2.retentionDays || h.lastDayIndex != h2.lastDayIndex {
+		return false
+	}
+	for day := 0; day < h.retentionDays; day++ {
+		if h.bucketForDay[day] != h2.bucketForDay[day] {
+			return false
+		}
+	}
+	return true
+}
+
+func (h *binaryDecayingHistogram) SaveToChekpoint() (*vpa_types.HistogramCheckpoint, error) {
+	result := vpa_types.HistogramCheckpoint{
+		BucketWeights:      make(map[int]uint32),
+		ReferenceTimestamp: metav1.NewTime(time.Unix(int64(h.lastDayIndex*60*60*24), 0)),
+	}
+	for day := h.lastDayIndex; day > h.lastDayIndex-h.retentionDays && day >= 0; day-- {
+		bucket := h.bucketForDay[day%h.retentionDays]
+		if bucket > 0 {
+			intIndex := (h.lastDayIndex - day) / 32
+			bucketBase := intIndex * h.options.NumBuckets()
+			bucketIndex := bucketBase + int(bucket) - 1
+			bitIndex := (h.lastDayIndex - day) % 32
+			result.BucketWeights[bucketIndex] |= 1 << bitIndex
+		}
+	}
+	return &result, nil
+}
+
+func (h *binaryDecayingHistogram) LoadFromCheckpoint(checkpoint *vpa_types.HistogramCheckpoint) error {
+	if checkpoint == nil {
+		return fmt.Errorf("cannot load from empty checkpoint")
+	}
+	h.lastDayIndex = h.dayIndex(checkpoint.ReferenceTimestamp.Time)
+	if h.lastDayIndex < 0 {
+		return fmt.Errorf("cannot load checkpoint with negative reference timestamp %v", checkpoint.ReferenceTimestamp.Time)
+	}
+	h.bucketForDay = make([]uint16, h.retentionDays)
+	if checkpoint.TotalWeight > 0 {
+		// Loading from checkpoint saved by a different histogram type.
+		// In this case we only extract max.
+		basicHistogram := NewHistogram(h.options)
+		basicHistogram.LoadFromCheckpoint(checkpoint)
+		h.AddSample(basicHistogram.Percentile(1.0), 1, time.Now())
+	} else {
+		for day := h.lastDayIndex; day > h.lastDayIndex-h.retentionDays && day >= 0; day-- {
+			intIndex := (h.lastDayIndex - day) / 32
+			bucketBase := intIndex * h.options.NumBuckets()
+			bitIndex := (h.lastDayIndex - day) % 32
+			for bucket := 1; bucket <= h.options.NumBuckets(); bucket++ {
+				bucketIndex := bucketBase + bucket - 1
+				if (checkpoint.BucketWeights[bucketIndex] & (1 << bitIndex)) != 0 {
+					h.bucketForDay[day%h.retentionDays] = uint16(bucket)
+					break
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/vertical-pod-autoscaler/pkg/recommender/util/binary_decaying_histogram_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/util/binary_decaying_histogram_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 )
 
 var (
@@ -292,6 +293,18 @@ func TestBinaryDecayingHistogramSaveToCheckpointEmpty(t *testing.T) {
 			assert.Equal(t, 0., s.TotalWeight)
 			assert.Len(t, s.BucketWeights, 0)
 			assert.Equal(t, time.Unix(0, 0), s.ReferenceTimestamp.Time)
+		})
+	}
+}
+
+func TestBinaryDecayingHistogramLoadFromEmptyCheckpoint(t *testing.T) {
+	for _, retentionDays := range retentionsToTest {
+		t.Run(fmt.Sprintf("retentionDays: %d", retentionDays), func(t *testing.T) {
+			h := NewBinaryDecayingHistogram(testBinaryDecayingHistogramOptions, retentionDays)
+			s := vpa_types.HistogramCheckpoint{}
+			err := h.LoadFromCheckpoint(&s)
+			assert.NoError(t, err)
+			assert.True(t, h.IsEmpty())
 		})
 	}
 }

--- a/vertical-pod-autoscaler/pkg/recommender/util/binary_decaying_histogram_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/util/binary_decaying_histogram_test.go
@@ -1,0 +1,389 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	bucketGrowth = 0.05
+	// Test histogram options.
+	testBinaryDecayingHistogramOptions, _ = NewExponentialHistogramOptions(1e12, 1e7, 1.+bucketGrowth, epsilon)
+
+	retentionsToTest = []int{30, 32, 60, 90, 120, 150, 180, 210, 240, 270, 300, 330, 360}
+
+	v128Mib        = float64(128 * 1024 * 1024)
+	v128MibEpsilon = bucketLength(testBinaryDecayingHistogramOptions, v128Mib) / v128Mib
+	v256Mib        = float64(128 * 1024 * 1024)
+	v256MibEpsilon = bucketLength(testBinaryDecayingHistogramOptions, v256Mib) / v256Mib
+)
+
+func bucketLength(options HistogramOptions, value float64) float64 {
+	bucket := options.FindBucket(value)
+	// special handling of the last bucket
+	if bucket == options.NumBuckets()-1 {
+		return options.GetBucketStart(bucket) - options.GetBucketStart(bucket-1)
+	} else {
+		return options.GetBucketStart(bucket+1) - options.GetBucketStart(bucket)
+	}
+}
+
+// Verifies that Percentile(1.0) returns 0.0 when called on an empty histogram for
+// any percentile.
+func TestPercentilesEmptyBinaryDecayingHistogram(t *testing.T) {
+	for _, retentionDays := range retentionsToTest {
+		t.Run(fmt.Sprintf("retentionDays: %d", retentionDays), func(t *testing.T) {
+			h := NewBinaryDecayingHistogram(testBinaryDecayingHistogramOptions, retentionDays)
+			assert.Equal(t, 0.0, h.Percentile(1.0))
+		})
+	}
+}
+
+func TestPercentilesBinaryDecayingHistogram(t *testing.T) {
+	for _, retentionDays := range retentionsToTest {
+		t.Run(fmt.Sprintf("retentionDays: %d", retentionDays), func(t *testing.T) {
+			h := NewBinaryDecayingHistogram(testBinaryDecayingHistogramOptions, retentionDays)
+			h.AddSample(v128Mib, 1.0, startTime)
+			assert.InEpsilon(t, v128Mib, h.Percentile(1.0), v128MibEpsilon)
+
+			// Adding more samples should not change the result.
+			h.AddSample(1024*1024, 1.0, startTime)
+			h.AddSample(1024*1024, 1.0, startTime)
+			assert.InEpsilon(t, v128Mib, h.Percentile(1.0), v128MibEpsilon)
+
+			// Adding smaller samples should not change the result.
+			h.AddSample(512*1024, 1.0, startTime)
+			h.AddSample(128*1024, 1.0, startTime)
+			assert.InEpsilon(t, v128Mib, h.Percentile(1.0), v128MibEpsilon)
+
+			// Adding higher samples should change the result.
+			h.AddSample(v256Mib, 1.0, startTime)
+			assert.InEpsilon(t, v256Mib, h.Percentile(1.0), v256MibEpsilon)
+		})
+	}
+}
+
+// Verifies that IsEmpty() returns true on an empty histogram and false otherwise.
+func TestEmptyBinaryDecayingHistogram(t *testing.T) {
+	for _, retentionDays := range retentionsToTest {
+		t.Run(fmt.Sprintf("retentionDays: %d", retentionDays), func(t *testing.T) {
+			h := NewBinaryDecayingHistogram(testBinaryDecayingHistogramOptions, retentionDays)
+			assert.True(t, h.IsEmpty())
+			h.AddSample(v128Mib, 1.0, startTime)
+			assert.False(t, h.IsEmpty())
+		})
+	}
+}
+
+func TestBinaryDecayingHistogramRetention(t *testing.T) {
+	for _, retentionDays := range retentionsToTest {
+		t.Run(fmt.Sprintf("retentionDays: %d", retentionDays), func(t *testing.T) {
+			h := NewBinaryDecayingHistogram(testBinaryDecayingHistogramOptions, retentionDays)
+			h.AddSample(v128Mib, 1.0, startTime)
+			assert.InEpsilon(t, v128Mib, h.Percentile(1.0), v128MibEpsilon)
+
+			dayIndex := int(startTime.Unix() / (60 * 60 * 24))
+			firstDayBeoyondRetention := dayIndex + retentionDays
+			firstDayBeoyondRetentionWindowStart := time.Unix(int64(firstDayBeoyondRetention*60*60*24), 0)
+
+			currentTime := startTime.Add(time.Minute)
+			// Iterate all minutes starting from the currentTime until the firstDayBeoyondRetentionWindowStart.
+			for currentTime.Before(firstDayBeoyondRetentionWindowStart) {
+				// low number between 10 and 69
+				lowNumber := float64(currentTime.Minute() + 10)
+
+				h.AddSample(lowNumber*1024*1024, 1.0, currentTime)
+				assert.InEpsilon(t, v128Mib, h.Percentile(1.0), v128MibEpsilon)
+
+				currentTime = currentTime.Add(time.Minute)
+			}
+
+			lastDay := firstDayBeoyondRetention + retentionDays
+			lastDayWindowStart := time.Unix(int64(lastDay*60*60*24), 0)
+
+			currentTime = currentTime.Add(time.Minute)
+			// Iterate all minutes starting from the firstDayBeoyondRetentionWindowStart until the lastDayWindowStart.
+			for currentTime.Before(lastDayWindowStart) {
+
+				h.AddSample(1, 1.0, currentTime)
+				assert.InEpsilon(t, 69*1024*1024, h.Percentile(1.0), bucketLength(testBinaryDecayingHistogramOptions, 69*1024*1024)/69*1024*1024)
+
+				currentTime = currentTime.Add(time.Minute)
+			}
+		})
+	}
+}
+
+func TestBinaryDecayingHistogramRetentionChange(t *testing.T) {
+	for _, retentionDays := range retentionsToTest {
+		t.Run(fmt.Sprintf("retentionDays: %d", retentionDays), func(t *testing.T) {
+			h := NewBinaryDecayingHistogram(testBinaryDecayingHistogramOptions, retentionDays)
+			shorter := NewBinaryDecayingHistogram(testBinaryDecayingHistogramOptions, retentionDays/2)
+			currentTime := startTime
+			lastTime := startTime.AddDate(2, 0, 0)
+			for currentTime.Before(lastTime) {
+				seconds := currentTime.Unix()
+				mb := float64(seconds%1000000) * 1024 * 1024
+				h.AddSample(mb, 1.0, currentTime)
+				shorter.AddSample(mb, 1.0, currentTime)
+				s, err := h.SaveToChekpoint()
+				assert.NoError(t, err)
+				loaded := NewBinaryDecayingHistogram(testBinaryDecayingHistogramOptions, retentionDays)
+				loaded.LoadFromCheckpoint(s)
+				assert.True(t, h.Equals(loaded))
+
+				loadedShorter := NewBinaryDecayingHistogram(testBinaryDecayingHistogramOptions, retentionDays/2)
+				loadedShorter.LoadFromCheckpoint(s)
+				assert.True(t, shorter.Equals(loadedShorter))
+
+				longer := NewBinaryDecayingHistogram(testBinaryDecayingHistogramOptions, retentionDays*2)
+				ct := currentTime
+				for i := 0; i < retentionDays && !ct.Before(startTime); i++ {
+					seconds := ct.Unix()
+					mb := float64(seconds%1000000) * 1024 * 1024
+					longer.AddSample(mb, 1.0, ct)
+					ct = ct.AddDate(0, 0, -1)
+				}
+				loadedLonger := NewBinaryDecayingHistogram(testBinaryDecayingHistogramOptions, retentionDays*2)
+				loadedLonger.LoadFromCheckpoint(s)
+				assert.True(t, longer.Equals(loadedLonger))
+
+				currentTime = currentTime.AddDate(0, 0, 1)
+			}
+
+		})
+	}
+}
+
+func TestBinaryDecayingHistogramMergeNonOverlappingLarger(t *testing.T) {
+	for _, retentionDays := range retentionsToTest {
+		t.Run(fmt.Sprintf("retentionDays: %d", retentionDays), func(t *testing.T) {
+			h1 := NewBinaryDecayingHistogram(testBinaryDecayingHistogramOptions, retentionDays)
+			h2 := NewBinaryDecayingHistogram(testBinaryDecayingHistogramOptions, retentionDays)
+			expected := NewBinaryDecayingHistogram(testBinaryDecayingHistogramOptions, retentionDays)
+			dayIndex := int(startTime.Unix() / (60 * 60 * 24))
+			for i := 0; i < retentionDays; i++ {
+				ts := time.Unix(int64((dayIndex+i)*60*60*24), 0)
+				h1.AddSample(float64((i+1)*1024*1024*1024), 1.0, ts)
+			}
+			for i := retentionDays; i < 2*retentionDays; i++ {
+				ts := time.Unix(int64((dayIndex+i)*60*60*24), 0)
+				h2.AddSample(float64((i+1)*1024*1024), 1.0, ts)
+				expected.AddSample(float64((i+1)*1024*1024), 1.0, ts)
+			}
+			h1.Merge(h2)
+			assert.True(t, h1.Equals(expected))
+		})
+	}
+}
+
+func TestBinaryDecayingHistogramMergeNonOverlappingSmaller(t *testing.T) {
+	for _, retentionDays := range retentionsToTest {
+		t.Run(fmt.Sprintf("retentionDays: %d", retentionDays), func(t *testing.T) {
+			h1 := NewBinaryDecayingHistogram(testBinaryDecayingHistogramOptions, retentionDays)
+			h2 := NewBinaryDecayingHistogram(testBinaryDecayingHistogramOptions, retentionDays)
+			expected := NewBinaryDecayingHistogram(testBinaryDecayingHistogramOptions, retentionDays)
+			dayIndex := int(startTime.Unix() / (60 * 60 * 24))
+			for i := 0; i < retentionDays; i++ {
+				ts := time.Unix(int64((dayIndex+i)*60*60*24), 0)
+				h2.AddSample(float64((i+1)*1024*1024*1024), 1.0, ts)
+			}
+			for i := retentionDays; i < 2*retentionDays; i++ {
+				ts := time.Unix(int64((dayIndex+i)*60*60*24), 0)
+				h1.AddSample(float64((i+1)*1024*1024), 1.0, ts)
+				expected.AddSample(float64((i+1)*1024*1024), 1.0, ts)
+			}
+			h1.Merge(h2)
+			assert.True(t, h1.Equals(expected))
+		})
+	}
+}
+
+func TestBinaryDecayingHistogramMergeOverlappingLarger(t *testing.T) {
+	for _, retentionDays := range retentionsToTest {
+		t.Run(fmt.Sprintf("retentionDays: %d", retentionDays), func(t *testing.T) {
+			h1 := NewBinaryDecayingHistogram(testBinaryDecayingHistogramOptions, retentionDays)
+			h2 := NewBinaryDecayingHistogram(testBinaryDecayingHistogramOptions, retentionDays)
+			expected := NewBinaryDecayingHistogram(testBinaryDecayingHistogramOptions, retentionDays)
+			dayIndex := int(startTime.Unix() / (60 * 60 * 24))
+			for i := 0; i < retentionDays; i++ {
+				ts := time.Unix(int64((dayIndex+i)*60*60*24), 0)
+				h1.AddSample(float64((i+1)*1024*1024), 1.0, ts)
+			}
+			for i := retentionDays - retentionDays/2; i < 2*retentionDays-retentionDays/2; i++ {
+				ts := time.Unix(int64((dayIndex+i)*60*60*24), 0)
+				h2.AddSample(float64((i+1)*1024*1024*1024), 1.0, ts)
+				expected.AddSample(float64((i+1)*1024*1024*1024), 1.0, ts)
+			}
+			h1.Merge(h2)
+			assert.True(t, h1.Equals(expected))
+		})
+	}
+}
+
+func TestBinaryDecayingHistogramMergeOverlappingSmaller(t *testing.T) {
+	for _, retentionDays := range retentionsToTest {
+		t.Run(fmt.Sprintf("retentionDays: %d", retentionDays), func(t *testing.T) {
+			h1 := NewBinaryDecayingHistogram(testBinaryDecayingHistogramOptions, retentionDays)
+			h2 := NewBinaryDecayingHistogram(testBinaryDecayingHistogramOptions, retentionDays)
+			expected := NewBinaryDecayingHistogram(testBinaryDecayingHistogramOptions, retentionDays)
+			dayIndex := int(startTime.Unix() / (60 * 60 * 24))
+			for i := 0; i < retentionDays; i++ {
+				ts := time.Unix(int64((dayIndex+i)*60*60*24), 0)
+				h1.AddSample(float64((i+1)*1024*1024*1024), 1.0, ts)
+			}
+			for i := retentionDays - retentionDays/2; i < 2*retentionDays-retentionDays/2; i++ {
+				ts := time.Unix(int64((dayIndex+i)*60*60*24), 0)
+				h2.AddSample(float64((i+1)*1024*1024), 1.0, ts)
+				expectedValue := float64((i + 1) * 1024 * 1024)
+				if i < retentionDays {
+					expectedValue = float64((i + 1) * 1024 * 1024 * 1024)
+				}
+				expected.AddSample(expectedValue, 1.0, ts)
+			}
+			h1.Merge(h2)
+			assert.True(t, h1.Equals(expected))
+		})
+	}
+}
+
+func TestBinaryDecayingHistogramMergeSame(t *testing.T) {
+	for _, retentionDays := range retentionsToTest {
+		t.Run(fmt.Sprintf("retentionDays: %d", retentionDays), func(t *testing.T) {
+			h := NewBinaryDecayingHistogram(testBinaryDecayingHistogramOptions, retentionDays)
+			expected := NewBinaryDecayingHistogram(testBinaryDecayingHistogramOptions, retentionDays)
+			dayIndex := int(startTime.Unix() / (60 * 60 * 24))
+			for i := 0; i < retentionDays; i++ {
+				ts := time.Unix(int64((dayIndex+i)*60*60*24), 0)
+				h.AddSample(float64((i+1)*1024*1024*1024), 1.0, ts)
+				expected.AddSample(float64((i+1)*1024*1024*1024), 1.0, ts)
+			}
+			h.Merge(expected)
+			assert.True(t, h.Equals(expected))
+		})
+	}
+}
+
+func TestBinaryDecayingHistogramSaveToCheckpointEmpty(t *testing.T) {
+	for _, retentionDays := range retentionsToTest {
+		t.Run(fmt.Sprintf("retentionDays: %d", retentionDays), func(t *testing.T) {
+			h := NewBinaryDecayingHistogram(testBinaryDecayingHistogramOptions, retentionDays)
+			s, err := h.SaveToChekpoint()
+			assert.NoError(t, err)
+			assert.Equal(t, 0., s.TotalWeight)
+			assert.Len(t, s.BucketWeights, 0)
+			assert.Equal(t, time.Unix(0, 0), s.ReferenceTimestamp.Time)
+		})
+	}
+}
+
+func TestBinaryDecayingHistogramSaveToCheckpoint(t *testing.T) {
+	for _, retentionDays := range retentionsToTest {
+		t.Run(fmt.Sprintf("retentionDays: %d", retentionDays), func(t *testing.T) {
+			h := NewBinaryDecayingHistogram(testBinaryDecayingHistogramOptions, retentionDays)
+			h.AddSample(v128Mib, 1.0, startTime)
+			s, err := h.SaveToChekpoint()
+			assert.NoError(t, err)
+			bucket := testBinaryDecayingHistogramOptions.FindBucket(v128Mib)
+			assert.Len(t, s.BucketWeights, 1)
+			assert.Contains(t, s.BucketWeights, bucket)
+			assert.Equal(t, uint32(1), s.BucketWeights[bucket])
+			assert.Equal(t, 0., s.TotalWeight)
+			dayIndex := int(startTime.Unix() / (60 * 60 * 24))
+			referenceTimestamp := time.Unix(int64(dayIndex*60*60*24), 0)
+			assert.Equal(t, referenceTimestamp, s.ReferenceTimestamp.Time)
+
+			// Perfect overlap, the same result is expected except for the reference timestamp.
+			h.AddSample(v128Mib, 1.0, startTime.AddDate(0, 0, retentionDays))
+			s, err = h.SaveToChekpoint()
+			assert.NoError(t, err)
+			bucket = testBinaryDecayingHistogramOptions.FindBucket(v128Mib)
+			assert.Len(t, s.BucketWeights, 1)
+			assert.Contains(t, s.BucketWeights, bucket)
+			assert.Equal(t, uint32(1), s.BucketWeights[bucket])
+			referenceTimestamp = time.Unix(int64((dayIndex+retentionDays)*60*60*24), 0)
+			assert.Equal(t, referenceTimestamp, s.ReferenceTimestamp.Time)
+			assert.Equal(t, 0., s.TotalWeight)
+
+			// Set highest bit
+			h.AddSample(v128Mib, 1.0, startTime.AddDate(0, 0, 2*retentionDays-1))
+			s, err = h.SaveToChekpoint()
+			assert.NoError(t, err)
+			fullInts := (retentionDays - 1) / 32
+			bucket = testBinaryDecayingHistogramOptions.FindBucket(v128Mib) + (fullInts * testBinaryDecayingHistogramOptions.NumBuckets())
+			if retentionDays <= 32 {
+				assert.Len(t, s.BucketWeights, 1)
+			} else {
+				assert.Len(t, s.BucketWeights, 2)
+			}
+			assert.Contains(t, s.BucketWeights, bucket)
+			if retentionDays == 30 {
+				assert.Equal(t, uint32(1<<29+1), s.BucketWeights[bucket])
+			} else if retentionDays == 32 {
+				assert.Equal(t, uint32(1<<31+1), s.BucketWeights[bucket])
+			} else {
+				// Only highest bit set
+				assert.Equal(t, uint32(1<<((retentionDays-1)%32)), s.BucketWeights[bucket])
+			}
+			referenceTimestamp = time.Unix(int64((dayIndex+2*retentionDays-1)*60*60*24), 0)
+			assert.Equal(t, referenceTimestamp, s.ReferenceTimestamp.Time)
+			assert.Equal(t, 0., s.TotalWeight)
+		})
+	}
+}
+
+func TestBinaryDecayingHistogramCheckpointing(t *testing.T) {
+	for _, retentionDays := range retentionsToTest {
+		t.Run(fmt.Sprintf("retentionDays: %d", retentionDays), func(t *testing.T) {
+			h := NewBinaryDecayingHistogram(testBinaryDecayingHistogramOptions, retentionDays)
+			currentTime := startTime
+			lastTime := startTime.AddDate(3, 0, 0)
+			for currentTime.Before(lastTime) {
+				seconds := currentTime.Unix()
+				mb := float64(seconds%1000000) * 1024 * 1024
+				h.AddSample(mb, 1.0, currentTime)
+				s, err := h.SaveToChekpoint()
+				assert.NoError(t, err)
+				loaded := NewBinaryDecayingHistogram(testBinaryDecayingHistogramOptions, retentionDays)
+				loaded.LoadFromCheckpoint(s)
+				assert.True(t, h.Equals(loaded))
+				currentTime = currentTime.AddDate(0, 0, 1)
+			}
+
+		})
+	}
+}
+
+func TestBinaryDecayingHistogramLoadFromDecayingHistogramCheckpoint(t *testing.T) {
+	for _, retentionDays := range retentionsToTest {
+		t.Run(fmt.Sprintf("retentionDays: %d", retentionDays), func(t *testing.T) {
+			h := NewDecayingHistogram(testBinaryDecayingHistogramOptions, time.Hour*24)
+			h.AddSample(v128Mib, 1.0, startTime)
+			h.AddSample(v256Mib, 1.0, startTime.AddDate(0, 0, 1))
+			s, err := h.SaveToChekpoint()
+			assert.NoError(t, err)
+			loaded := NewBinaryDecayingHistogram(testBinaryDecayingHistogramOptions, retentionDays)
+			loaded.LoadFromCheckpoint(s)
+			assert.InEpsilon(t, v256Mib, loaded.Percentile(1.0), v256MibEpsilon)
+		})
+	}
+}

--- a/vertical-pod-autoscaler/pkg/utils/metrics/quality/quality.go
+++ b/vertical-pod-autoscaler/pkg/utils/metrics/quality/quality.go
@@ -274,14 +274,14 @@ func ObserveQualityMetricsRecommendationMissing(usage float64, isOOM bool, resou
 }
 
 // ObserveRecommendationChange records relative_recommendation_changes metric.
-func ObserveRecommendationChange(previous, current corev1.ResourceList, updateMode *vpa_types.UpdateMode, vpaSize int) {
+func ObserveRecommendationChange(previous, current corev1.ResourceList, updateMode *vpa_types.UpdateMode, vpaSize int, namespace string, vpaName string, container string) {
 	// This will happen if there is no previous recommendation, we don't want to emit anything then.
 	if previous == nil {
 		return
 	}
 	// This is not really expected thus a warning.
 	if current == nil {
-		klog.Warningf("Cannot compare with current recommendation being nil. VPA mode: %v, size: %v", updateMode, vpaSize)
+		klog.Warningf("Cannot compare with current recommendation being nil. VPA mode: %v, size: %v, namesapce: %s, vpaName: %s, container: %s", *updateMode, vpaSize, namespace, vpaName, container)
 		return
 	}
 
@@ -294,7 +294,7 @@ func ObserveRecommendationChange(previous, current corev1.ResourceList, updateMo
 			log2 := metrics.GetVpaSizeLog2(vpaSize)
 			relativeRecommendationChange.WithLabelValues(updateModeToString(updateMode), string(resource), strconv.Itoa(log2)).Observe(diff)
 		} else {
-			klog.Warningf("Cannot compare as old recommendation for %v is 0. VPA mode: %v, size: %v", resource, updateMode, vpaSize)
+			klog.Warningf("Cannot compare as old recommendation for %v is 0. VPA mode: %v, size: %v, namesapce: %s, vpaName: %s, container: %s", resource, *updateMode, vpaSize, namespace, vpaName, container)
 		}
 	}
 }


### PR DESCRIPTION
#### What type of PR is this?
This PR adds binary decaying histogram and uses it for RSS and JVM heap recommendations.
This histogram has the following properties:
- It only supports max (100th percentile).
- It does not support subtracting samples.
- Can load checkpoint saved by default decaying histogram and uses just max from it.
- Can load from checkpoint with a different retentionDays parameter (it allows us changing this config without loosing history). In the future we might add support for per-VPA configurable retentionDays, if needed.
- Checkpoint contains all data, samples are not lost on VPA restart.
- RetentionDays can be arbitrary large.

Beside that this PR fixes and extends information logged in `quality.go`. It is unrelated change but helps with troubleshooting issues.

We also make a change so that the recommendation for JVM heap is not created if there are no samples collected.

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
