### PR TITLE
Handle JVM Heap OOMs

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -185,7 +185,7 @@ type clusterStateFeeder struct {
 	coreClient          corev1.CoreV1Interface
 	specClient          spec.SpecClient
 	metricsClient       metrics.MetricsClient
-	oomChan             <-chan oom.OomInfo
+	oomChan             <-chan []oom.OomInfo
 	vpaCheckpointClient vpa_api.VerticalPodAutoscalerCheckpointsGetter
 	vpaLister           vpa_lister.VerticalPodAutoscalerLister
 	clusterState        *model.ClusterState
@@ -442,21 +442,13 @@ func (feeder *clusterStateFeeder) LoadRealTimeMetrics() {
 Loop:
 	for {
 		select {
-		case oomInfo := <-feeder.oomChan:
-			klog.V(3).Infof("OOM detected %+v", oomInfo)
-			// On JVM Heap OOM, we need special handling.
-			// We must also add an RSS peak OOM (with value of memory limit), in order to keep the delta between RSS and JVM Heap the same or higher.
-			// When adding a JVM Heap OOM sample, we add a sample in the next biggest histogram bucket.
-			// Since RSS value is guaranteed to be greater than Heap, we add an oom sample in the RSS histogram as well,
-			// which is guaranteed to be the same increase or larger.
-			if oomInfo.Resource == model.ResourceJVMHeapCommitted {
-				if err = feeder.clusterState.RecordOOM(oomInfo.ContainerID, oomInfo.Timestamp, model.ResourceRSS, oomInfo.MemoryLimit); err != nil {
+		case oomInfos := <-feeder.oomChan:
+			for _, oomInfo := range oomInfos {
+				klog.V(3).Infof("OOM detected %+v", oomInfo)
+
+				if err = feeder.clusterState.RecordOOM(oomInfo.ContainerID, oomInfo.Timestamp, oomInfo.Resource, oomInfo.Memory); err != nil {
 					klog.Warningf("Failed to record OOM %+v. Reason: %+v", oomInfo, err)
 				}
-				klog.V(6).Infof("OOM Handling for JVM Heap, adding JVM Heap OOM sample with value %f and RSS OOM sample with value %f", oomInfo.Memory, oomInfo.MemoryLimit)
-			}
-			if err = feeder.clusterState.RecordOOM(oomInfo.ContainerID, oomInfo.Timestamp, oomInfo.Resource, oomInfo.Memory); err != nil {
-				klog.Warningf("Failed to record OOM %+v. Reason: %+v", oomInfo, err)
 			}
 		default:
 			break Loop

--- a/vertical-pod-autoscaler/pkg/recommender/input/oom/observer_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/oom/observer_test.go
@@ -181,6 +181,7 @@ func TestJVMHeapOOMReceived(t *testing.T) {
 	timestamp, err := time.Parse(time.RFC3339, "2018-02-23T13:38:48Z")
 	assert.NoError(t, err)
 	assert.Equal(t, timestamp.Unix(), info.Timestamp.Unix())
+	assert.Equal(t, model.ResourceAmount(int64(2048)), info.MemoryLimit)
 }
 
 func TestMalformedPodReceived(t *testing.T) {

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
@@ -207,12 +207,6 @@ func (a *AggregateContainerState) AddSample(sample *ContainerUsageSample) {
 		// Special OOM handling for binary decaying histogram.
 		if sample.isOOM {
 			a.AggregateJVMHeapCommittedPeaks.AddOomSample(BytesFromMemoryAmount(sample.Usage), 1.0, sample.MeasureStart)
-			// We need to add an RSS peak OOM as well, as if we bump up the JVM heap recommendation, the RSS recommendation
-			// must be bumped up by the same amount or more.
-			// In this case, we are adding a JVM Heap OOM sample, which adds a sample in the next biggest bucket size.
-			// RSS OOM sample will also add a sample in the next bucket as well, which is guaranteed to be the same increase or larger.
-			rssPeakRecommendation := a.AggregateRSSPeaks.Percentile(1.0)
-			a.AggregateRSSPeaks.AddOomSample(rssPeakRecommendation, 1.0, sample.MeasureStart)
 		} else {
 			a.AggregateJVMHeapCommittedPeaks.AddSample(BytesFromMemoryAmount(sample.Usage), 1.0, sample.MeasureStart)
 		}

--- a/vertical-pod-autoscaler/pkg/recommender/model/cluster_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/cluster_test.go
@@ -343,14 +343,11 @@ func TestClusterRecordOOMJvmHeapComitted(t *testing.T) {
 	// Get current peaks of JVM Heap Committed and RSS for comparison
 	aggregation := cluster.findOrCreateAggregateContainerState(testContainerID)
 	prevJVMHeapCommitted := aggregation.AggregateJVMHeapCommittedPeaks.Percentile(1.0)
-	prevRSS := aggregation.AggregateRSSPeaks.Percentile(1.0)
 	assert.NoError(t, cluster.RecordOOM(testContainerID, testTimestamp, ResourceJVMHeapCommitted, ResourceAmount(40.0*1024*1024*1024)))
 
 	// Verify that OOM was aggregated into the aggregated stats.
 	assert.Greaterf(t, aggregation.AggregateJVMHeapCommittedPeaks.Percentile(1.0), prevJVMHeapCommitted, "JVM Heap Committed should be greater than previous value")
-	// For JVM Heap OOM, we also add an OOM sample to RSS.
-	assert.Greaterf(t, aggregation.AggregateRSSPeaks.Percentile(1.0), prevRSS, "RSS should be greater than previous value")
-
+	assert.NotZero(t, aggregation.AggregateJVMHeapCommittedPeaks.Percentile(1.0))
 }
 
 // Verifies that AddSample and AddOrUpdateContainer methods return a proper

--- a/vertical-pod-autoscaler/pkg/recommender/model/container_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/container_test.go
@@ -255,9 +255,7 @@ func TestRecordOOMRSSConsecutive(t *testing.T) {
 func TestRecordOOMJvmHeapCommittedConsecutive(t *testing.T) {
 	test := newContainerTest()
 
-	test.mockRSSHistogram.On("Percentile", 1.0).Return(1000.0 * mb)
 	test.mockJVMHeapHistogram.On("AddOomSample", 900.0*mb, 1.0, testTimestamp)
-	test.mockRSSHistogram.On("AddOomSample", 1000.0*mb, 1.0, testTimestamp)
 	assert.NoError(t, test.container.RecordOOM(testTimestamp, ResourceJVMHeapCommitted, ResourceAmount(900*mb)))
 
 	// Smaller OOMs are also recorded.


### PR DESCRIPTION
Handle the signal for JVM Heap OOM, by watching the `LastTerminationState.Terminated.Reason == "JVM Heap OOM"`. This signal is propagated on JVM Heap OOM when a service is using the newly added `java_cmd` wrapper with autopilot jvm flags set to true.

On Heap OOM signal, we parse out the JVM Heap Size and use this as an artificial jvm heap committed oom sample (where the histogram will add a sample for the next bucket size up).
Additionally, we must also add a sample to the RSS histogram.
The reasoning for this is as follows:
1. We are adding a jvm heap committed sample in one bucket higher than the previous heap committed value.
2. We must maintain the same buffer (at least) between RSS and JVM Heap Committed (RSS > JVM Heap)
3. In order to do this, we simply use the invariant that bucket sizes are increasing, and add an RSS oom sample at the highest value recorded in the current histogram, in order to also bump up the value by 1 bucket.

We do this by adding extending oomInfo channel to []oomInfo, and on JVM heap oom, record both the JVM heap oom and RSS oom.

Details from testing can be found here: https://docs.google.com/document/d/1TEu-KjkemR7MJYJUN2GXv_I2FrEO-CtFvM9K43WQR2s/edit?tab=t.0
