### PR TITLE
Add numBuckets to histogram checkpoint, write to annotations on VPA Checkpoint CR

### DIFF
--- a/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
+++ b/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go
@@ -427,4 +427,8 @@ type HistogramCheckpoint struct {
 
 	// Sum of samples to be used as denominator for weights from BucketWeights.
 	TotalWeight float64 `json:"totalWeight,omitempty" protobuf:"bytes,3,opt,name=totalWeight"`
+
+	// Number of buckets in the histogram, which corresponds to the growth rate of each bucket.
+	// Only used for RSS and JVM Heap bucket scheme migration.
+	NumBuckets int `json:"numBuckets,omitempty" protobuf:"bytes,4,opt,name=numBuckets"`
 }

--- a/vertical-pod-autoscaler/pkg/recommender/util/binary_decaying_histogram.go
+++ b/vertical-pod-autoscaler/pkg/recommender/util/binary_decaying_histogram.go
@@ -235,6 +235,7 @@ func (h *binaryDecayingHistogram) SaveToChekpoint() (*vpa_types.HistogramCheckpo
 	result := vpa_types.HistogramCheckpoint{
 		BucketWeights:      make(map[int]uint32),
 		ReferenceTimestamp: metav1.NewTime(time.Unix(int64(h.lastDayIndex*60*60*24), 0)),
+		NumBuckets:         h.options.NumBuckets(),
 	}
 	for day := h.lastDayIndex; day > h.lastDayIndex-h.retentionDays && day >= 0; day-- {
 		bucket := h.bucketForDay[day%h.retentionDays]

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api.go
@@ -196,6 +196,11 @@ func CreateOrUpdateVpaCheckpoint(vpaCheckpointClient vpa_api.VerticalPodAutoscal
 		Path:  "/status",
 		Value: vpaCheckpoint.Status,
 	})
+	patches = append(patches, patchRecord{
+		Op:    "replace",
+		Path:  "/metadata/annotations",
+		Value: vpaCheckpoint.Annotations,
+	})
 	bytes, err := json.Marshal(patches)
 	if err != nil {
 		return fmt.Errorf("Cannot marshal VPA checkpoint status patches %+v. Reason: %+v", patches, err)


### PR DESCRIPTION
Adds `numBuckets` to the HistogramCheckpoint struct, which is passed from the checkpoint writer and cluster state feeder. This field is *not* added to the CRD, to get around all CRD versioning difficulties, and is only utilized internally in the controller code.

Instead, we parse the number of buckets (which corresponds directly with bucket growth rate), and write the value to an annotation on the VPA checkpoint CR itself.

In a follow up PR, we will handle the read path, and actually utilize this value.

This is a prerequisite to bucket scheme migration from 5% to 1% for binary decaying histograms.

**Testing**
Deployed to dev-azure-westus
<img width="814" alt="image" src="https://github.com/user-attachments/assets/88e4b190-dfb5-4bac-9d95-b22209a54632">
