### PR TITLE
Add conversion from 5% bucketing scheme in binary decaying histogram

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
@@ -183,8 +183,8 @@ func NewAggregateContainerState() *AggregateContainerState {
 	return &AggregateContainerState{
 		AggregateCPUUsage:              util.NewDecayingHistogram(config.CPUHistogramOptions, config.CPUHistogramDecayHalfLife),
 		AggregateMemoryPeaks:           util.NewDecayingHistogram(config.MemoryHistogramOptions, config.MemoryHistogramDecayHalfLife),
-		AggregateRSSPeaks:              util.NewBinaryDecayingHistogram(config.MemoryHistogramOptions, config.CustomMemoryHistogramRetentionDays),
-		AggregateJVMHeapCommittedPeaks: util.NewBinaryDecayingHistogram(config.MemoryHistogramOptions, config.CustomMemoryHistogramRetentionDays),
+		AggregateRSSPeaks:              util.NewBinaryDecayingHistogram(config.BinaryDecayingHistogramOptions, config.CustomMemoryHistogramRetentionDays),
+		AggregateJVMHeapCommittedPeaks: util.NewBinaryDecayingHistogram(config.BinaryDecayingHistogramOptions, config.CustomMemoryHistogramRetentionDays),
 		CreationTime:                   time.Now(),
 	}
 }

--- a/vertical-pod-autoscaler/pkg/recommender/util/binary_decaying_histogram.go
+++ b/vertical-pod-autoscaler/pkg/recommender/util/binary_decaying_histogram.go
@@ -297,7 +297,8 @@ func (h *binaryDecayingHistogram) LoadFromCheckpoint(checkpoint *vpa_types.Histo
 	// 176 buckets indicates 5% growth rate.
 	// We don't dynamically calculate the growth rate because from numBuckets because it is not accurate due to floating points and rounding.
 	if checkpoint.NumBuckets != h.options.NumBuckets() {
-		if checkpoint.NumBuckets == 176 {
+		// If the checkpoint has 0 numBuckets, it means that the checkpoint has not been saved with the NumBuckets annotation, meaning it was the old default scheme of 5%.
+		if checkpoint.NumBuckets == 176 || checkpoint.NumBuckets == 0 {
 			oldOptions := &exponentialHistogramOptions{
 				numBuckets:      checkpoint.NumBuckets,
 				firstBucketSize: 1e7,
@@ -313,7 +314,6 @@ func (h *binaryDecayingHistogram) LoadFromCheckpoint(checkpoint *vpa_types.Histo
 			oldH.LoadFromCheckpointInternal(checkpoint)
 			h.convertFromDifferentHistogramBucketScheme(oldH)
 		} else if checkpoint.NumBuckets != 0 {
-			// If the checkpoint has 0 numBuckets, it means that the Checkpoint doesn't have this histogram at all.
 			return fmt.Errorf("cannot load from checkpoint: checkpoint has different number of buckets %d than the histogram %d", checkpoint.NumBuckets, h.options.NumBuckets())
 		}
 	}

--- a/vertical-pod-autoscaler/pkg/recommender/util/binary_decaying_histogram.go
+++ b/vertical-pod-autoscaler/pkg/recommender/util/binary_decaying_histogram.go
@@ -300,7 +300,7 @@ func (h *binaryDecayingHistogram) LoadFromCheckpoint(checkpoint *vpa_types.Histo
 		// If the checkpoint has 0 numBuckets, it means that the checkpoint has not been saved with the NumBuckets annotation, meaning it was the old default scheme of 5%.
 		if checkpoint.NumBuckets == 176 || checkpoint.NumBuckets == 0 {
 			oldOptions := &exponentialHistogramOptions{
-				numBuckets:      checkpoint.NumBuckets,
+				numBuckets:      176,
 				firstBucketSize: 1e7,
 				ratio:           1.05,
 				epsilon:         h.options.Epsilon(),
@@ -314,7 +314,7 @@ func (h *binaryDecayingHistogram) LoadFromCheckpoint(checkpoint *vpa_types.Histo
 			oldH.LoadFromCheckpointInternal(checkpoint)
 			h.convertFromDifferentHistogramBucketScheme(oldH)
 		} else if checkpoint.NumBuckets != 0 {
-			return fmt.Errorf("cannot load from checkpoint: checkpoint has different number of buckets %d than the histogram %d", checkpoint.NumBuckets, h.options.NumBuckets())
+			panic(fmt.Sprintf("cannot load from checkpoint:  checkpoint has different number of buckets %d than the histogram %d", checkpoint.NumBuckets, h.options.NumBuckets()))
 		}
 	}
 	return h.LoadFromCheckpointInternal(checkpoint)

--- a/vertical-pod-autoscaler/pkg/recommender/util/binary_decaying_histogram.go
+++ b/vertical-pod-autoscaler/pkg/recommender/util/binary_decaying_histogram.go
@@ -312,7 +312,8 @@ func (h *binaryDecayingHistogram) LoadFromCheckpoint(checkpoint *vpa_types.Histo
 				retentionDays: h.retentionDays,
 			}
 			oldH.LoadFromCheckpointInternal(checkpoint)
-			h.convertFromDifferentHistogramBucketScheme(oldH)
+			h.lastDayIndex = h.dayIndex(checkpoint.ReferenceTimestamp.Time)
+			return h.convertFromDifferentHistogramBucketScheme(oldH)
 		} else if checkpoint.NumBuckets != 0 {
 			panic(fmt.Sprintf("cannot load from checkpoint:  checkpoint has different number of buckets %d than the histogram %d", checkpoint.NumBuckets, h.options.NumBuckets()))
 		}
@@ -322,12 +323,13 @@ func (h *binaryDecayingHistogram) LoadFromCheckpoint(checkpoint *vpa_types.Histo
 
 // convertFromDifferentHistogramBucketScheme converts the binary decaying histogram with a different number of buckets to bucket scheme of the calling histogram.
 // This is done by finding the corresponding bucket value for each day in the old histogram and storing it in the new histogram.
-func (h *binaryDecayingHistogram) convertFromDifferentHistogramBucketScheme(oldHistogram *binaryDecayingHistogram) {
+func (h *binaryDecayingHistogram) convertFromDifferentHistogramBucketScheme(oldHistogram *binaryDecayingHistogram) error {
 	for dayIndex, bucketIndex := range oldHistogram.bucketForDay {
 		if bucketIndex != 0 {
-			memValue := oldHistogram.options.GetBucketStart(int(bucketIndex)) // Maybe -1
+			memValue := oldHistogram.options.GetBucketStart(int(bucketIndex))
 			newBucketIndex := h.options.FindBucket(memValue)
 			h.bucketForDay[dayIndex] = uint16(newBucketIndex)
 		}
 	}
+	return nil
 }

--- a/vertical-pod-autoscaler/pkg/recommender/util/binary_decaying_histogram_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/util/binary_decaying_histogram_test.go
@@ -402,7 +402,8 @@ func TestBinaryDecayingHistogramCheckpointing(t *testing.T) {
 func TestBinaryDecayingHistogramLoadFromDecayingHistogramCheckpoint(t *testing.T) {
 	for _, retentionDays := range retentionsToTest {
 		t.Run(fmt.Sprintf("retentionDays: %d", retentionDays), func(t *testing.T) {
-			h := NewDecayingHistogram(testBinaryDecayingHistogramOptions, time.Hour*24)
+			testDecayingHistogramOptions, _ := NewExponentialHistogramOptions(1e12, 1e7, 1.+0.05, epsilon)
+			h := NewDecayingHistogram(testDecayingHistogramOptions, time.Hour*24)
 			h.AddSample(v128Mib, 1.0, startTime)
 			h.AddSample(v256Mib, 1.0, startTime.AddDate(0, 0, 1))
 			s, err := h.SaveToChekpoint()

--- a/vertical-pod-autoscaler/pkg/recommender/util/binary_decaying_histogram_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/util/binary_decaying_histogram_test.go
@@ -32,10 +32,15 @@ var (
 
 	retentionsToTest = []int{30, 32, 60, 90, 120, 150, 180, 210, 240, 270, 300, 330, 360}
 
+	// We calculate epsilon for 128MiB and 256MiB to use in assert.InEpsilon.
+	// Epsilon values are not absolute differences, but rather fractions. assert.InEpislon uses the following formula:
+	// |expected - actual| / |expected| <= epsilon
 	v128Mib        = float64(128 * 1024 * 1024)
-	v128MibEpsilon = bucketLength(testBinaryDecayingHistogramOptions, v128Mib)
+	v128MibEpsilon = bucketLength(testBinaryDecayingHistogramOptions, v128Mib) / v128Mib
 	v256Mib        = float64(256 * 1024 * 1024)
-	v256MibEpsilon = bucketLength(testBinaryDecayingHistogramOptions, v256Mib)
+	v256MibEpsilon = bucketLength(testBinaryDecayingHistogramOptions, v256Mib) / v256Mib
+	v512Mib        = float64(512 * 1024 * 1024)
+	v512MibEpsilon = bucketLength(testBinaryDecayingHistogramOptions, v512Mib) / v512Mib
 )
 
 func bucketLength(options HistogramOptions, value float64) float64 {
@@ -417,17 +422,21 @@ func TestBinaryDecayingHistogramLoadFromDecayingHistogramCheckpoint(t *testing.T
 
 func TestBinaryDecayingHistogramLoadFromDifferentCheckpointBucketGrowthScheme(t *testing.T) {
 	for _, retentionDays := range retentionsToTest {
-		fivePctBinaryDecayingHistogramOptions, _ := NewExponentialHistogramOptions(1e12, 1e7, 1.05, epsilon)
-		hOld := NewBinaryDecayingHistogram(fivePctBinaryDecayingHistogramOptions, retentionDays)
-		hOld.AddSample(v128Mib, 1.0, startTime)
-		hOld.AddSample(v256Mib, 1.0, startTime.AddDate(0, 0, 1))
-		s, err := hOld.SaveToChekpoint()
-		assert.NoError(t, err)
+		t.Run(fmt.Sprintf("retentionDays: %d", retentionDays), func(t *testing.T) {
+			fivePctBinaryDecayingHistogramOptions, _ := NewExponentialHistogramOptions(1e12, 1e7, 1.05, epsilon)
+			hOld := NewBinaryDecayingHistogram(fivePctBinaryDecayingHistogramOptions, retentionDays)
+			hOld.AddSample(v128Mib, 1.0, startTime)
+			hOld.AddSample(v256Mib, 1.0, startTime.AddDate(0, 0, 1))
+			hOld.AddSample(v512Mib, 1.0, startTime.AddDate(0, 0, 30))
+			s, err := hOld.SaveToChekpoint()
+			assert.NoError(t, err)
 
-		// One percent bucketing scheme
-		hNew := NewBinaryDecayingHistogram(testBinaryDecayingHistogramOptions, retentionDays)
-		err = hNew.LoadFromCheckpoint(s)
-		assert.NoError(t, err)
-		assert.InEpsilon(t, v256Mib, hNew.Percentile(1.0), v256MibEpsilon)
+			// One percent bucketing scheme
+			hNew := NewBinaryDecayingHistogram(testBinaryDecayingHistogramOptions, retentionDays)
+			err = hNew.LoadFromCheckpoint(s)
+			assert.NoError(t, err)
+			assert.InEpsilon(t, v512Mib, hNew.Percentile(1.0), v512MibEpsilon)
+
+		})
 	}
 }


### PR DESCRIPTION
Adds conversion logic to convert from 5% bucketing scheme to new default (1%).

We first check for annotations on the VPA Checkpoint CR, and parse the number of buckets for each binary decaying histogram.
Since we cannot easily convert from number of buckets to growth rate (due to floating point + rounding), we only support the 5% growth rate case (176 buckets).

This PR also fixes a couple tests (oom adding to +1 bucket test), as well as the epsilon values, which were incorrectly dividing the bucket length by the actual value. Instead, we should just be checking the bucket length.

## Testing
Successfully deployed this change to `dev-azure-westus` - vpa recommender is healthy and processing VPA objects.
Additionally, number of buckets changed from 176 (5%) to 696 (1%)
<img width="738" alt="image" src="https://github.com/user-attachments/assets/e3735fd0-69e7-49ef-94a1-6b8ae37e3d45">

Additionally spot checked a number of VPA objects + VPA checkpoints ([doc](https://docs.google.com/document/d/1Vph62EVfQNpOtZro9RhJmU8eEapUCcCNuAQrRJLmySI/edit?tab=t.0)) and saw that recommendations did not change (outside of bounds of bucketing scheme change error), and vpa checkpoints change as expected.

**Before**
<img width="727" alt="image" src="https://github.com/user-attachments/assets/feff0a3f-4a8f-4343-802a-d5f740f57f5f">
<img width="728" alt="image" src="https://github.com/user-attachments/assets/8defa6e0-34eb-4af8-bf6c-a4507e4be5e1">


**After**
<img width="690" alt="image" src="https://github.com/user-attachments/assets/4e64fba4-7caf-4cae-bfc7-25451de335c1">
<img width="767" alt="image" src="https://github.com/user-attachments/assets/3a1b2e2e-e833-48a5-9eec-d21a75da73ec">

