### PR TITLE
Early return when standard pod metrics list is nil

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
@@ -128,7 +128,7 @@ func (s podMetricsSource) List(ctx context.Context, namespace string, opts v1.Li
 	close(customResChan)
 
 	podMetrics := <-resChan
-	if s.customMetricsLister == nil {
+	if podMetrics == nil || s.customMetricsLister == nil {
 		return podMetrics, nil
 	}
 


### PR DESCRIPTION
The standard pod metrics (CPU, memory) are augmented with custom metrics data. When the LIST of those standard pod metrics is nil, we should return early to avoid a nil pointer dereference panic.