### PR TITLE
Add tool to decode histograms from a checkpoint.

### DIFF
--- a/vertical-pod-autoscaler/pkg/decode-histogram/Dockerfile
+++ b/vertical-pod-autoscaler/pkg/decode-histogram/Dockerfile
@@ -1,0 +1,22 @@
+# Copyright 2016 The Kubernetes Authors. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+FROM gcr.io/distroless/static:latest
+
+ARG ARCH
+COPY updater-$ARCH /decode-histogram
+
+ENTRYPOINT ["/decode-histogram"]
+CMD ["--v=4", "--stderrthreshold=info"]

--- a/vertical-pod-autoscaler/pkg/decode-histogram/Makefile
+++ b/vertical-pod-autoscaler/pkg/decode-histogram/Makefile
@@ -1,0 +1,107 @@
+all: build
+
+TAG?=dev
+REGISTRY?=staging-k8s.gcr.io
+FLAGS=
+TEST_ENVVAR=LD_FLAGS=-s GO111MODULE=on
+ENVVAR=CGO_ENABLED=0 $(TEST_ENVVAR)
+GOOS?=linux
+COMPONENT=decode-histogram
+FULL_COMPONENT=vpa-${COMPONENT}
+
+ALL_ARCHITECTURES?=amd64 arm arm64 ppc64le s390x
+export DOCKER_CLI_EXPERIMENTAL=enabled
+
+build: clean
+	$(ENVVAR) GOOS=$(GOOS) go build ./...
+	$(ENVVAR) GOOS=$(GOOS) go build -o ${COMPONENT}
+
+build-binary: clean
+	$(ENVVAR) GOOS=$(GOOS) go build -o ${COMPONENT}
+
+.PHONY: build-binary-with-vendor
+build-binary-with-vendor: $(addprefix build-binary-with-vendor-,$(ALL_ARCHITECTURES)) clean
+
+.PHONY: build-binary-with-vendor-*
+build-binary-with-vendor-%:
+	$(ENVVAR) GOARCH=$* GOOS=$(GOOS) go build -mod vendor -o ${COMPONENT}-$*
+
+test-unit: clean build
+	$(TEST_ENVVAR) go test --test.short -race ./... $(FLAGS)
+
+.PHONY: docker-build
+docker-build: $(addprefix docker-build-,$(ALL_ARCHITECTURES))
+
+.PHONY: docker-build-*
+docker-build-%:
+ifndef REGISTRY
+	ERR = $(error REGISTRY is undefined)
+	$(ERR)
+endif
+ifndef TAG
+	ERR = $(error TAG is undefined)
+	$(ERR)
+endif
+	docker buildx build --pull --load --platform linux/$* -t ${REGISTRY}/${FULL_COMPONENT}-$*:${TAG} --build-arg ARCH=$* .
+
+.PHONY: docker-push
+docker-push: $(addprefix sub-push-,$(ALL_ARCHITECTURES)) push-multi-arch;
+
+.PHONY: sub-push-*
+sub-push-%: docker-build-% do-push-% ;
+
+.PHONY: do-push-*
+do-push-%:
+ifndef REGISTRY
+	ERR = $(error REGISTRY is undefined)
+	$(ERR)
+endif
+ifndef TAG
+	ERR = $(error TAG is undefined)
+	$(ERR)
+endif
+	docker push ${REGISTRY}/${FULL_COMPONENT}-$*:${TAG}
+
+.PHONY: push-multi-arch
+push-multi-arch:
+	docker manifest create --amend $(REGISTRY)/${FULL_COMPONENT}:$(TAG) $(shell echo $(ALL_ARCHITECTURES) | sed -e "s~[^ ]*~$(REGISTRY)/${FULL_COMPONENT}\-&:$(TAG)~g")
+	@for arch in $(ALL_ARCHITECTURES); do docker manifest annotate --arch $${arch} $(REGISTRY)/${FULL_COMPONENT}:$(TAG) $(REGISTRY)/${FULL_COMPONENT}-$${arch}:${TAG}; done
+	docker manifest push --purge $(REGISTRY)/${FULL_COMPONENT}:$(TAG)
+
+docker-builder:
+	docker build -t vpa-autoscaling-builder ../../builder
+
+.PHONY: build-in-docker
+build-in-docker: $(addprefix build-in-docker-,$(ALL_ARCHITECTURES))
+
+.PHONY: build-in-docker-*
+build-in-docker-%: clean docker-builder
+	echo '=============== local git status ==============='
+	git status
+	echo '=============== last commit ==============='
+	git log -1
+	echo '=============== bulding from the above ==============='
+	docker run -v `pwd`/../..:/gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler vpa-autoscaling-builder:latest bash -c 'cd /gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler && make build-binary-with-vendor-$* -C pkg/updater'
+
+.PHONY: create-buildx-builder
+create-buildx-builder:
+	BUILDER=$(shell docker buildx create --driver=docker-container --use)
+
+.PHONY: remove-buildx-builder
+remove-buildx-builder:
+	docker buildx rm ${BUILDER}
+
+.PHONY: release
+release: build-in-docker create-buildx-builder docker-build remove-buildx-builder docker-push
+	@echo "Full in-docker release ${FULL_COMPONENT}:${TAG} completed"
+
+clean: $(addprefix clean-,$(ALL_ARCHITECTURES))
+
+clean-%:
+	rm -f ${COMPONENT}-$*
+
+format:
+	test -z "$$(find . -path ./vendor -prune -type f -o -name '*.go' -exec gofmt -s -d {} + | tee /dev/stderr)" || \
+	test -z "$$(find . -path ./vendor -prune -type f -o -name '*.go' -exec gofmt -s -w {} + | tee /dev/stderr)"
+
+.PHONY: all build test-unit clean format release

--- a/vertical-pod-autoscaler/pkg/decode-histogram/main.go
+++ b/vertical-pod-autoscaler/pkg/decode-histogram/main.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+
+	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/input"
+	"k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/model"
+)
+
+func main() {
+	// Read VPA checkpoint JSON from standard input
+	checkpointData, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		log.Fatalf("Error reading from stdin: %v", err)
+	}
+	// Parse the JSON into a VPA checkpoint structure
+	var checkpoint vpa_types.VerticalPodAutoscalerCheckpoint
+	err = json.Unmarshal(checkpointData, &checkpoint)
+	if err != nil {
+		log.Fatalf("Error unmarshalling JSON: %v", err)
+	}
+
+	err = input.SetNumBucketsFromAnnotations(&checkpoint)
+	if err != nil {
+		log.Fatalf("Error loading from checkpoint: %v", err)
+	}
+
+	// Create a new AggregateContainerState
+	aggregateState := model.NewAggregateContainerState()
+	// Load data into the AggregateContainerState using LoadFromCheckpoint
+	err = aggregateState.LoadFromCheckpoint(&checkpoint.Status)
+	if err != nil {
+		log.Fatalf("Error loading from checkpoint: %v", err)
+	}
+
+	fmt.Printf("CPU histogram:\n%v\n", aggregateState.AggregateCPUUsage)
+	fmt.Printf("\nRSS Usage:\n%v\n", aggregateState.AggregateRSSPeaks)
+	fmt.Printf("\nJVM Heap Committed Usage\n%v\n", aggregateState.AggregateJVMHeapCommittedPeaks)
+}

--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -228,13 +228,7 @@ func (feeder *clusterStateFeeder) InitFromHistoryProvider(historyProvider histor
 	}
 }
 
-func (feeder *clusterStateFeeder) setVpaCheckpoint(checkpoint *vpa_types.VerticalPodAutoscalerCheckpoint) error {
-	vpaID := model.VpaID{Namespace: checkpoint.Namespace, VpaName: checkpoint.Spec.VPAObjectName}
-	vpa, exists := feeder.clusterState.Vpas[vpaID]
-	if !exists {
-		return fmt.Errorf("cannot load checkpoint to missing VPA object %+v", vpaID)
-	}
-
+func SetNumBucketsFromAnnotations(checkpoint *vpa_types.VerticalPodAutoscalerCheckpoint) error {
 	// Check for numBuckets annotations for JVM Heap and RSS histograms.
 	if checkpoint.Annotations != nil {
 		rssNumBucketsStr, ok := checkpoint.Annotations[checkpointwriter.RSSBinaryDecayingHistogramNumBuckets]
@@ -254,9 +248,23 @@ func (feeder *clusterStateFeeder) setVpaCheckpoint(checkpoint *vpa_types.Vertica
 			checkpoint.Status.JVMHeapCommittedHistogram.NumBuckets = jvmHeapNumBuckets
 		}
 	}
+	return nil
+}
+
+func (feeder *clusterStateFeeder) setVpaCheckpoint(checkpoint *vpa_types.VerticalPodAutoscalerCheckpoint) error {
+	vpaID := model.VpaID{Namespace: checkpoint.Namespace, VpaName: checkpoint.Spec.VPAObjectName}
+	vpa, exists := feeder.clusterState.Vpas[vpaID]
+	if !exists {
+		return fmt.Errorf("cannot load checkpoint to missing VPA object %+v", vpaID)
+	}
+
+	err := SetNumBucketsFromAnnotations(checkpoint)
+	if err != nil {
+		return err
+	}
 
 	cs := model.NewAggregateContainerState()
-	err := cs.LoadFromCheckpoint(&checkpoint.Status)
+	err = cs.LoadFromCheckpoint(&checkpoint.Status)
 	if err != nil {
 		return fmt.Errorf("cannot load checkpoint for VPA %+v. Reason: %v", vpa.ID, err)
 	}

--- a/vertical-pod-autoscaler/pkg/recommender/util/binary_decaying_histogram.go
+++ b/vertical-pod-autoscaler/pkg/recommender/util/binary_decaying_histogram.go
@@ -229,7 +229,7 @@ func (h *binaryDecayingHistogram) String() string {
 			value = h.valueForBucket(int(bucket) - 1)
 		}
 		lines = append(lines, fmt.Sprintf("%s\t%s",
-			time.Unix(int64(day*60*60*24), 0).Format("2006-01-02"),
+			time.Unix(int64(day*60*60*24), 0).UTC().Format("2006-01-02"),
 			addThousandSeparators(int64(value/1024/1024))+"Mi"))
 	}
 	lines = append(lines, "\n")

--- a/vertical-pod-autoscaler/pkg/recommender/util/binary_decaying_histogram.go
+++ b/vertical-pod-autoscaler/pkg/recommender/util/binary_decaying_histogram.go
@@ -18,6 +18,7 @@ package util
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -196,10 +197,30 @@ func (h *binaryDecayingHistogram) valueForBucket(bucket int) float64 {
 	return h.options.GetBucketStart(bucket)
 }
 
+// Add this helper function
+func addThousandSeparators(n int64) string {
+	str := strconv.FormatInt(n, 10)
+	if len(str) <= 3 {
+		return str
+	}
+
+	// Start from the end and insert commas every 3 digits
+	var result []byte
+	for i, j := len(str)-1, 0; i >= 0; i-- {
+		if j > 0 && j%3 == 0 {
+			result = append([]byte{','}, result...)
+		}
+		result = append([]byte{str[i]}, result...)
+		j++
+	}
+	return string(result)
+}
+
 func (h *binaryDecayingHistogram) String() string {
 	lines := []string{
 		fmt.Sprintf("retentionDays: %d", h.retentionDays),
-		"day\tbucket\tvalue",
+		fmt.Sprintf("max: %s", addThousandSeparators(int64(h.Percentile(1.0)/1024/1024))+"Mi"),
+		"day\tvalue",
 	}
 	for day := h.lastDayIndex; day > h.lastDayIndex-h.retentionDays && day >= 0; day-- {
 		bucket := h.bucketForDay[day%h.retentionDays]
@@ -207,7 +228,9 @@ func (h *binaryDecayingHistogram) String() string {
 		if bucket > 0 {
 			value = h.valueForBucket(int(bucket) - 1)
 		}
-		lines = append(lines, fmt.Sprintf("%d\t%d\t%.3f", day, bucket, value))
+		lines = append(lines, fmt.Sprintf("%s\t%s",
+			time.Unix(int64(day*60*60*24), 0).Format("2006-01-02"),
+			addThousandSeparators(int64(value/1024/1024))+"Mi"))
 	}
 	lines = append(lines, "\n")
 	return strings.Join(lines, "\n")


### PR DESCRIPTION
#### What type of PR is this?

The new tool is useful for debugging and troubleshooting.
It reads checkpoint formatted as json from standard input, parses it and prints out histograms in a human readable form.

To build on macbook:
```
cd vertical-pod-autoscaler/pkg/decode-histogram
GOOS=darwin GOARCH=arm64 make build
```

Run:
```
kubectl --context <context> get VerticalPodAutoscalerCheckpoint <name> --namespace <namespace> -o json | ./decode-histogram
```

Example output:
```
CPU histogram:
referenceTimestamp: 2024-11-17 16:00:00 -0800 PST, halfLife: 24h0m0s
minBucket: 0, maxBucket: 5, totalWeight: 2472.881
%-tile  value
0       0.010
5       0.010
10      0.010
15      0.010
20      0.010
25      0.010
30      0.010
35      0.010
40      0.020
45      0.020
50      0.020
55      0.020
60      0.020
65      0.020
70      0.020
75      0.020
80      0.020
85      0.020
90      0.020
95      0.020
100     0.068

RSS Usage:
retentionDays: 90
max: 3,331Mi
day     value
2024-11-15      1,077Mi
2024-11-14      1,404Mi
2024-11-13      1,118Mi
2024-11-12      1,268Mi
2024-11-11      1,335Mi
2024-11-10      1,268Mi
2024-11-09      960Mi
2024-11-08      960Mi
2024-11-07      1,202Mi
2024-11-06      1,077Mi
2024-11-05      1,867Mi
2024-11-04      3,003Mi
2024-11-03      1,202Mi
2024-11-02      1,018Mi
2024-11-01      1,018Mi
2024-10-31      1,428Mi
2024-10-30      1,600Mi
2024-10-29      3,331Mi
2024-10-28      1,867Mi
2024-10-27      1,139Mi
2024-10-26      960Mi
2024-10-25      960Mi
2024-10-24      1,428Mi
2024-10-23      1,358Mi
2024-10-22      1,077Mi
2024-10-21      1,268Mi
2024-10-20      1,202Mi
2024-10-19      849Mi
2024-10-18      849Mi
2024-10-17      1,077Mi
2024-10-16      1,202Mi
2024-10-15      903Mi
2024-10-14      849Mi
2024-10-13      1,677Mi
2024-10-12      1,018Mi
2024-10-11      1,018Mi
2024-10-10      1,018Mi
2024-10-09      1,077Mi
2024-10-08      960Mi
2024-10-07      1,139Mi
2024-10-06      1,202Mi
2024-10-05      849Mi
2024-10-04      849Mi
2024-10-03      1,202Mi
2024-10-02      1,139Mi
2024-10-01      1,500Mi
2024-09-30      1,268Mi
2024-09-29      1,268Mi
2024-09-28      1,202Mi
2024-09-27      1,268Mi
2024-09-26      1,202Mi
2024-09-25      1,202Mi
2024-09-24      2,454Mi
2024-09-23      903Mi
2024-09-22      1,202Mi
2024-09-21      849Mi
2024-09-20      849Mi
2024-09-19      1,500Mi
2024-09-18      2,886Mi
2024-09-17      1,202Mi
2024-09-16      2,193Mi
2024-09-15      1,139Mi
2024-09-14      849Mi
2024-09-13      849Mi
2024-09-12      849Mi
2024-09-11      1,077Mi
2024-09-10      960Mi
2024-09-09      1,139Mi
2024-09-08      1,202Mi
2024-09-07      1,139Mi
2024-09-06      796Mi
2024-09-05      796Mi
2024-09-04      0Mi
2024-09-03      0Mi
2024-09-02      0Mi
2024-09-01      0Mi
2024-08-31      0Mi
2024-08-30      0Mi
2024-08-29      0Mi
2024-08-28      0Mi
2024-08-27      0Mi
2024-08-26      0Mi
2024-08-25      0Mi
2024-08-24      0Mi
2024-08-23      0Mi
2024-08-22      0Mi
2024-08-21      0Mi
2024-08-20      0Mi
2024-08-19      0Mi
2024-08-18      0Mi



JVM Heap Committed Usage
retentionDays: 90
max: 0Mi
day     value
1969-12-31      0Mi
```



<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
