### PR TITLE
Do not prematurely GC aggregate container states with OOM samples

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
@@ -334,7 +334,7 @@ func (a *AggregateContainerState) isExpired(now time.Time) bool {
 	if a.isEmpty() {
 		return now.Sub(a.CreationTime) >= maxRetention
 	}
-	return now.Sub(a.LastSampleStart) >= maxRetention
+	return !a.LastSampleStart.IsZero() && now.Sub(a.LastSampleStart) >= maxRetention
 }
 
 // isEmpty returns true if the aggregate container state is empty.

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
@@ -314,7 +314,7 @@ func (a *AggregateContainerState) isExpired(now time.Time) bool {
 }
 
 func (a *AggregateContainerState) isEmpty() bool {
-	return a.TotalSamplesCount == 0
+	return a.TotalSamplesCount == 0 && a.AggregateCPUUsage.IsEmpty() && a.AggregateMemoryPeaks.IsEmpty() && a.AggregateRSSPeaks.IsEmpty() && a.AggregateJVMHeapCommittedPeaks.IsEmpty()
 }
 
 // UpdateFromPolicy updates container state scaling mode and controlled resources based on resource

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state.go
@@ -306,15 +306,51 @@ func (a *AggregateContainerState) LoadFromCheckpoint(checkpoint *vpa_types.Verti
 	return nil
 }
 
+// Each aggregate container state has an aggregation key, i.e. ID of namespace + container name + pod labels.
+// Upon workload re-creation, since pod labels may change (e.g. pod-template-hash), the aggregation key may change,
+// so the VPA (for that workload) may track multiple aggregate container states for a given container.
+//
+// To generate recommendations for that given container, all corresponding aggregate container states are merged.
+// Note that this is not a destructive merge. All original aggregate container states are still tracked by the VPA.
+// Every time a recommendation is generated, the merge happens in a fresh aggregate container state that is then discarded.
+//
+// When an aggregate container state is GC'ed, it no longer contributes to the merge and hence the recommendation.
+
+// isExpired returns true if the aggregate container state is expired.
+// The aggregate container state is GC'ed when it is expired.
+//
+// The native implementation only checked that time elapsed since the last update >= memory aggregation window.
+// This is no longer sufficient, and instead should be >= max(memory aggregation window, custom memory histogram retention).
+//
+// This change is to account for the custom memory histogram retention used by the RSS and JVM heap recommendations.
+// Since they take the max usage over this retention period, no samples over this time can be discarded.
 func (a *AggregateContainerState) isExpired(now time.Time) bool {
-	if a.isEmpty() {
-		return now.Sub(a.CreationTime) >= GetAggregationsConfig().GetMemoryAggregationWindowLength()
+	config := GetAggregationsConfig()
+	maxRetention := config.GetMemoryAggregationWindowLength()
+	if customMemoryRetention := 24 * time.Hour * time.Duration(config.CustomMemoryHistogramRetentionDays); customMemoryRetention > maxRetention {
+		maxRetention = customMemoryRetention
 	}
-	return now.Sub(a.LastSampleStart) >= GetAggregationsConfig().GetMemoryAggregationWindowLength()
+
+	if a.isEmpty() {
+		return now.Sub(a.CreationTime) >= maxRetention
+	}
+	return now.Sub(a.LastSampleStart) >= maxRetention
 }
 
+// isEmpty returns true if the aggregate container state is empty.
+// The aggregate container state is GC'ed when it is both empty and there are no existing associated Pods.
+//
+// The native implementation only checked a.TotalSamplesCount == 0, which is the count of standard CPU samples.
+// This is no longer sufficient, and instead all histograms are explicitly checked to be empty.
+//
+// This change is due to the following factors:
+//  1. An external OOM mitigation mechanism re-creates workloads upon OOMs.
+//     The VPA (for an OOM'ed workload) would have both the old and new aggregate container states.
+//  2. If a workload were to OOM immediately upon startup and then be immediately re-created by the OOM mitigation mechanism,
+//     the old aggregate container state would have a.TotalSamplesCount == 0, but it would have OOM samples.
+//     This old aggregate container state should not be GC'ed.
 func (a *AggregateContainerState) isEmpty() bool {
-	return a.TotalSamplesCount == 0 && a.AggregateCPUUsage.IsEmpty() && a.AggregateMemoryPeaks.IsEmpty() && a.AggregateRSSPeaks.IsEmpty() && a.AggregateJVMHeapCommittedPeaks.IsEmpty()
+	return a.AggregateCPUUsage.IsEmpty() && a.AggregateMemoryPeaks.IsEmpty() && a.AggregateRSSPeaks.IsEmpty() && a.AggregateJVMHeapCommittedPeaks.IsEmpty()
 }
 
 // UpdateFromPolicy updates container state scaling mode and controlled resources based on resource

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state_test.go
@@ -202,14 +202,13 @@ func TestAggregateContainerStateLoadFromCheckpoint(t *testing.T) {
 func TestAggregateContainerStateIsExpired(t *testing.T) {
 	cs := NewAggregateContainerState()
 	cs.LastSampleStart = testTimestamp
-	cs.TotalSamplesCount = 1
-	assert.False(t, cs.isExpired(testTimestamp.Add(90*24*time.Hour)))
+	cs.AggregateCPUUsage.AddSample(1, 33, testTimestamp)
+	assert.False(t, cs.isExpired(testTimestamp.Add(89*24*time.Hour)))
 	assert.True(t, cs.isExpired(testTimestamp.Add(91*24*time.Hour)))
 
 	csEmpty := NewAggregateContainerState()
-	csEmpty.TotalSamplesCount = 0
 	csEmpty.CreationTime = testTimestamp
-	assert.False(t, csEmpty.isExpired(testTimestamp.Add(90*24*time.Hour)))
+	assert.False(t, csEmpty.isExpired(testTimestamp.Add(89*24*time.Hour)))
 	assert.True(t, csEmpty.isExpired(testTimestamp.Add(91*24*time.Hour)))
 }
 

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state_test.go
@@ -209,8 +209,8 @@ func TestAggregateContainerStateIsExpired(t *testing.T) {
 	csEmpty := NewAggregateContainerState()
 	csEmpty.TotalSamplesCount = 0
 	csEmpty.CreationTime = testTimestamp
-	assert.False(t, csEmpty.isExpired(testTimestamp.Add(7*24*time.Hour)))
-	assert.True(t, csEmpty.isExpired(testTimestamp.Add(8*24*time.Hour)))
+	assert.False(t, csEmpty.isExpired(testTimestamp.Add(90*24*time.Hour)))
+	assert.True(t, csEmpty.isExpired(testTimestamp.Add(91*24*time.Hour)))
 }
 
 func TestUpdateFromPolicyScalingMode(t *testing.T) {

--- a/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/aggregate_container_state_test.go
@@ -203,8 +203,8 @@ func TestAggregateContainerStateIsExpired(t *testing.T) {
 	cs := NewAggregateContainerState()
 	cs.LastSampleStart = testTimestamp
 	cs.TotalSamplesCount = 1
-	assert.False(t, cs.isExpired(testTimestamp.Add(7*24*time.Hour)))
-	assert.True(t, cs.isExpired(testTimestamp.Add(8*24*time.Hour)))
+	assert.False(t, cs.isExpired(testTimestamp.Add(90*24*time.Hour)))
+	assert.True(t, cs.isExpired(testTimestamp.Add(91*24*time.Hour)))
 
 	csEmpty := NewAggregateContainerState()
 	csEmpty.TotalSamplesCount = 0

--- a/vertical-pod-autoscaler/pkg/recommender/model/cluster_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/cluster_test.go
@@ -110,8 +110,8 @@ func TestClusterGCAggregateContainerStateDeletesOld(t *testing.T) {
 	assert.NotEmpty(t, cluster.aggregateStateMap)
 	assert.NotEmpty(t, vpa.aggregateContainerStates)
 
-	// AggregateContainerState are valid for 8 days since last sample
-	cluster.garbageCollectAggregateCollectionStates(usageSample.MeasureStart.Add(9*24*time.Hour), testControllerFetcher)
+	// AggregateContainerState are valid for 90 days since last sample
+	cluster.garbageCollectAggregateCollectionStates(usageSample.MeasureStart.Add(91*24*time.Hour), testControllerFetcher)
 
 	// AggregateContainerState should be deleted from both cluster and vpa
 	assert.Empty(t, cluster.aggregateStateMap)
@@ -141,8 +141,8 @@ func TestClusterGCAggregateContainerStateDeletesOldEmpty(t *testing.T) {
 	assert.NotEmpty(t, cluster.aggregateStateMap)
 	assert.NotEmpty(t, vpa.aggregateContainerStates)
 
-	// AggregateContainerState are valid for 8 days since creation
-	cluster.garbageCollectAggregateCollectionStates(creationTime.Add(9*24*time.Hour), testControllerFetcher)
+	// AggregateContainerState are valid for 90 days since creation
+	cluster.garbageCollectAggregateCollectionStates(creationTime.Add(91*24*time.Hour), testControllerFetcher)
 
 	// AggregateContainerState should be deleted from both cluster and vpa
 	assert.Empty(t, cluster.aggregateStateMap)
@@ -250,8 +250,8 @@ func TestAddSampleAfterAggregateContainerStateGCed(t *testing.T) {
 	aggregateStateKey := cluster.aggregateStateKeyForContainerID(testContainerID)
 	assert.Contains(t, vpa.aggregateContainerStates, aggregateStateKey)
 
-	// AggregateContainerState are invalid after 8 days since last sample
-	gcTimestamp := usageSample.MeasureStart.Add(10 * 24 * time.Hour)
+	// AggregateContainerState are invalid after 90 days since last sample
+	gcTimestamp := usageSample.MeasureStart.Add(100 * 24 * time.Hour)
 	cluster.garbageCollectAggregateCollectionStates(gcTimestamp, testControllerFetcher)
 
 	assert.Empty(t, cluster.aggregateStateMap)
@@ -274,7 +274,7 @@ func TestClusterGCRateLimiting(t *testing.T) {
 	// Create a pod with a single container.
 	cluster := NewClusterState(testGcPeriod)
 	usageSample := makeTestUsageSample()
-	sampleExpireTime := usageSample.MeasureStart.Add(9 * 24 * time.Hour)
+	sampleExpireTime := usageSample.MeasureStart.Add(91 * 24 * time.Hour)
 	// AggregateContainerState are valid for 8 days since last sample but this run
 	// doesn't remove the sample, because we didn't add it yet.
 	cluster.RateLimitedGarbageCollectAggregateCollectionStates(sampleExpireTime, testControllerFetcher)


### PR DESCRIPTION
Handles a subtle edge case in which aggregate container states would be prematurely garbage collected, resulting in unexpected dips to `RSS` and `JVM heap` recommendations. This PR updates the conditions for garbage collection to fix both the integration with the external OOM mitigation mechanism (re-creates workloads with the latest memory recommendations upon OOMs) and with the binary decaying histograms used by `RSS` and `JVM heap` recommendations.  <img width="979" alt="Screenshot 2024-11-20 at 5 33 57 PM" src="https://github.com/user-attachments/assets/977bc9cc-4797-4e76-9edb-34d3cf04ca18">


**Context**
RSS and JVM heap (custom memory recommendations)

  - `RSS` and `JVM heap` samples are added to binary decaying histograms to recommend the max usage over the last 90 days (default). 
  - OOMs contribute fake samples of the memory limits to the next higher histogram bucket. 
  - Hence, upon the contribution of a sample of value `x`, the recommendations should be at least `x` for the next 90 days. However, as seen above, recommendations would dip within an hour.

Aggregate container states
  - Each aggregate container state has an aggregation key, i.e. ID of namespace + container name + pod labels. Upon workload re-creation, since pod labels may change (e.g. pod-template-hash), the aggregation key may change, so the VPA (for that workload) may track multiple aggregate container states for a given container.
  - To generate recommendations for that given container, all corresponding aggregate container states are merged. Note that this is not a destructive merge. All original aggregate container states are still tracked by the VPA. Every time a recommendation is generated, the merge happens in a fresh aggregate container state that is then discarded.
  - When an aggregate container state is GC'ed, it no longer contributes to the merge and hence the recommendation. It is GC'ed when it is expired or when it is empty and there are no existing associated Pods.

**Root Cause**
The root cause was premature garbage collection due to the following:
1. An external OOM mitigation mechanism re-creates workloads upon OOMs. The VPA (for an OOM'ed workload) would have both the old and new aggregate container states.
2. If a workload were to OOM immediately upon startup and then be immediately re-created by the OOM mitigation mechanism, the old aggregate container state would be considered "empty" and then be GC'ed, but it should not have been as it had OOM samples.  Once GC'ed, it would not contribute to the recommendation, so the recommendation would drop, as seen above. This PR updates `isEmpty` so that such an aggregate container state would not be considered "empty".

This PR also fixes another GC-related bug in the integration with the binary decaying histograms. Originally, aggregate container states older than 7 days would be considered "expired" and then be GC'ed. However, since binary decaying histograms recommend the max usage over the last 90 days, they should not expire for the next 90 days. This PR updates `isExpired` so that such an aggregate container state would not be considered "expired".

**Validation**
VPA Recommender with the fix ([PR](https://github.com/jodzga/autoscaler/pull/39)) was deployed to dev-azure-koreacentral. 
- 5 OOM mitigations were triggered in quick succession for vpa-test-service (within 1m of each other). This means that the 4 intermediary workload re-creations would have created 4 old aggregate container states that would have only had time to collect OOM samples and likely no CPU usage samples (old empty GC condition). 
- After 1h elapsed (garbage collection interval), the recommendations did not regress, as desired because the new empty GC condition fixes it so that those 4 old aggregate container states with only OOM samples are not GC’ed.
<img width="867" alt="Screenshot 2024-11-21 at 11 32 21 AM" src="https://github.com/user-attachments/assets/439afdfd-3994-45e9-8fb2-c84f4ea8d624">
