### PR TITLE
change update vpa status to use merge

### DIFF
--- a/vertical-pod-autoscaler/pkg/utils/vpa/api.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"k8s.io/utils/pointer"
 	"strings"
 	"time"
 
@@ -35,7 +36,6 @@ import (
 	vpa_lister "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/listers/autoscaling.k8s.io/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
-	"k8s.io/utils/pointer"
 )
 
 // VpaWithSelector is a pair of VPA and its selector.
@@ -67,14 +67,14 @@ func patchVpaStatus(vpaClient vpa_api.VerticalPodAutoscalerInterface, vpaName st
 		return
 	}
 
-	// Define patch options with Server-Side Apply and Force set to true
 	opts := meta.PatchOptions{
 		FieldManager: "vpa-controller",
-		Force:        pointer.Bool(true),
 	}
 
-	// Apply the patch using Server-Side Apply
-	return vpaClient.Patch(context.TODO(), vpaName, types.ApplyPatchType, bytes, opts, "status")
+	// We use the Merge Patch type here to handle the case where the VPA resource has been updated since we last read it by another controller or CLI.
+	// This occurs if the current matched recommendations are empty, if the workload was deleted and we no longer have a pod selector, and thus have no recommendations.
+	// In this case, we want to ensure that we're able to write the status, even with an empty recommendation rather than getting an error from the API server.
+	return vpaClient.Patch(context.TODO(), vpaName, types.MergePatchType, bytes, opts, "status")
 }
 
 // patchVpaAnnotations updates the annotations of a VerticalPodAutoscaler object using


### PR DESCRIPTION
Changes VPA to update VPA statuses with merge, rather than apply.
This is required for the automated VPA workload kind migration. 

Autopilot’s cleanup handler decides to delete a VPA if the Condition ConfigUnsupported exists on the Status of a VPA CR. This condition is added to the status by VPA itself, when it sees that a VPA does not target a valid workload in the cluster. Normally this works just fine, as VPA controller is the only entity to update the status field. However, we are now introducing another entity, Kubecfg, which adds recommendations copied from the old VPA we’re migrating from.

This poses a problem for using the current apply patch method. API Server will reject an update if there are null fields in the patch, but those are non-null in the existing object. VPA’s update loop contains logic to determine a pod selector from a VPA’s target workload, in order to match aggregate container states to the VPA and produce recommendations. When the target workload no longer exists in the cluster, the pod selector becomes nil, and so do the recommendations, resulting in VPA controller’s apply patch to contain nil recommendations, while they exist on the VPA CR in the cluster from the Kubecfg copy.

Instead, we can circumvent this issue by changing VPA controller’s update method to merge patch, as it will only update specified fields in the update operation itself - namely Conditions, in this case. This will complete the feedback loop from VPA to Autopilot in order to clean up stale VPA objects.

Full doc: https://docs.google.com/document/d/1P96VCWvay2SxRpzXoKzfvFHObZ853chIxRR2skMa9Yk/edit?tab=t.0#bookmark=id.cb414hjcq1q


Tested in a cluster - saw all status updates were succeeding, including the ones that were resulting from a migration, where a workload no longer exists, but recommendations are present.