### PR TITLE
update timestamp parsing

### DIFF
--- a/vertical-pod-autoscaler/pkg/utils/vpa/api.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api.go
@@ -130,14 +130,15 @@ func annotationsAreStaleAndChanged(
 	for _, key := range keys {
 		newValue, newExists := newAnnotations[key]
 		oldValue, oldExists := oldAnnotations[key]
-    if (oldValue == ""){
-      return true
-    }
+		if !oldExists || oldValue == "" { // update if old annotations are missing
+			return true
+		}
 		oldTime, oldErr := time.Parse(time.RFC3339, oldValue)
 		if oldErr != nil {
 			klog.Errorf("Error parsing time: %+v", oldErr)
+			return true
 		}
-		if (!oldExists || oldErr != nil || oldTime.Before(staleThreshold)) &&
+		if (oldTime.Before(staleThreshold)) &&
 			(newExists && newValue != oldValue) {
 			return true
 		}

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api.go
@@ -130,7 +130,9 @@ func annotationsAreStaleAndChanged(
 	for _, key := range keys {
 		newValue, newExists := newAnnotations[key]
 		oldValue, oldExists := oldAnnotations[key]
-
+    if (oldValue == ""){
+      return true
+    }
 		oldTime, oldErr := time.Parse(time.RFC3339, oldValue)
 		if oldErr != nil {
 			klog.Errorf("Error parsing time: %+v", oldErr)

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api.go
@@ -130,7 +130,7 @@ func annotationsAreStaleAndChanged(
 	for _, key := range keys {
 		newValue, newExists := newAnnotations[key]
 		oldValue, oldExists := oldAnnotations[key]
-		if !oldExists || oldValue == "" { // update if old annotations are missing
+		if !oldExists {
 			return true
 		}
 		oldTime, oldErr := time.Parse(time.RFC3339, oldValue)


### PR DESCRIPTION
update timestamp parsing to automatically recognize empty timestamps as stale annotations.
As part of a previous update to add freshness annotations, a function was introduced to check if an annotation was stale. In the event of an empty annotation, the function would attempt to parse a timestamp, fail, and then consider the annotation stale and update it. 
By first checking if the annotation is empty before parsing the timestamp, less errors are logged.
There is no functionality change, as both cases see the empty annotation as stale.

This change will reduce the number of errors logged, making debugging easier

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Reduces error logging, making debugging easier.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
