### PR TITLE
Fix index out of range panic due to adding sampe that is out of range.

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/util/binary_decaying_histogram.go
+++ b/vertical-pod-autoscaler/pkg/recommender/util/binary_decaying_histogram.go
@@ -86,6 +86,9 @@ func (h *binaryDecayingHistogram) dayIndex(ts time.Time) int {
 }
 
 func (h *binaryDecayingHistogram) addSampleToBucket(bucket uint16, dayIndex int) {
+	if bucket >= uint16(h.options.NumBuckets()) {
+		bucket = uint16(h.options.NumBuckets() - 1)
+	}
 	if h.lastDayIndex > 0 {
 		// Ignore samples too far in the past
 		if dayIndex <= h.lastDayIndex-h.retentionDays {

--- a/vertical-pod-autoscaler/pkg/recommender/util/binary_decaying_histogram_test.go
+++ b/vertical-pod-autoscaler/pkg/recommender/util/binary_decaying_histogram_test.go
@@ -440,3 +440,19 @@ func TestBinaryDecayingHistogramLoadFromDifferentCheckpointBucketGrowthScheme(t 
 		})
 	}
 }
+
+func TestBinaryDecayingHistogramRepeatedOomSamples(t *testing.T) {
+	for _, retentionDays := range retentionsToTest {
+		t.Run(fmt.Sprintf("retentionDays: %d", retentionDays), func(t *testing.T) {
+			h := NewBinaryDecayingHistogram(testBinaryDecayingHistogramOptions, retentionDays)
+			value := v128Mib
+			for i := 0; i < 1000; i++ {
+				// Adding Oom sample increases the max value of the histogram by one bucket
+				h.AddOomSample(value, 1.0, startTime)
+				assert.NotPanics(t, func() {
+					value = h.Percentile(1.0)
+				})
+			}
+		})
+	}
+}

--- a/vertical-pod-autoscaler/pkg/utils/vpa/api.go
+++ b/vertical-pod-autoscaler/pkg/utils/vpa/api.go
@@ -20,9 +20,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"k8s.io/utils/pointer"
 	"strings"
 	"time"
+
+	"k8s.io/utils/pointer"
 
 	core "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -130,7 +131,7 @@ func annotationsAreStaleAndChanged(
 	for _, key := range keys {
 		newValue, newExists := newAnnotations[key]
 		oldValue, oldExists := oldAnnotations[key]
-		if !oldExists {
+		if !oldExists || oldValue == "" {
 			return true
 		}
 		oldTime, oldErr := time.Parse(time.RFC3339, oldValue)


### PR DESCRIPTION
This case might occur if RSS memory limit is not capped and we have large number of OOMKills.

Example panic:
```
panic: index 696 out of range [0..695]

goroutine 1 [running]:
k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/util.(*exponentialHistogramOptions).GetBucketStart(0xc00e945e80, 0x1?)
	/gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/util/histogram_options.go:136 +0xe9
k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/util.(*binaryDecayingHistogram).valueForBucket(0xc016886840, 0x2b8)
	/gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/util/binary_decaying_histogram.go:197 +0x63
k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/util.(*binaryDecayingHistogram).Percentile(0x177a500?, 0xc0272ad890?)
	/gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/util/binary_decaying_histogram.go:176 +0x65
k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/logic.(*percentileEstimator).GetResourceEstimation(0xc00bd613c0, 0xc008ec6b40)
	/gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/logic/estimator.go:103 +0x13c
k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/logic.(*marginEstimator).GetResourceEstimation(0xc003187950, 0x418268?)
	/gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/logic/estimator.go:146 +0x33
k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/logic.(*minResourcesEstimator).GetResourceEstimation(0xc006752768, 0x410225?)
	/gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/logic/estimator.go:156 +0x33
k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/logic.(*podResourceRecommender).estimateContainerResources(0xc0417fd3a8, 0xc008ec6b40)
	/gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/logic/recommender.go:90 +0x3a
k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/logic.(*podResourceRecommender).GetRecommendedPodResources(0xc00bd99f20, 0xc0272ad800)
	/gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/logic/recommender.go:82 +0x5d7
k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/routines.(*recommender).UpdateVPAs(0xc013462000)
	/gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go:96 +0x23e
k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/routines.(*recommender).RunOnce(0xc013462000)
	/gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/routines/recommender.go:196 +0x35f
main.main()
	/gopath/src/k8s.io/autoscaler/vertical-pod-autoscaler/pkg/recommender/main.go:217 +0x1492
```

Verified that unit test reproduces the problem before the fix.

At the same time we fix a small issue where we see large number of parsing errors like this:
```
E0213 07:32:17.546531       1 api.go:136] Error parsing time: parsing time "" as "2006-01-02T15:04:05Z07:00": cannot parse "" as "2006"
E0213 07:32:17.546536       1 api.go:136] Error parsing time: parsing time "" as "2006-01-02T15:04:05Z07:00": cannot parse "" as "2006"
```


#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
