### PR TITLE
fail on startup when checkpoints cannot be read

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -289,14 +289,14 @@ func (feeder *clusterStateFeeder) InitFromCheckpoints() {
 		klog.V(3).Infof("Fetching checkpoints from namespace %s", namespace)
 		checkpointList, err := feeder.vpaCheckpointClient.VerticalPodAutoscalerCheckpoints(namespace).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
-			klog.Errorf("Cannot list VPA checkpoints from namespace %v. Reason: %+v", namespace, err)
+			klog.Fatalf("Cannot list VPA checkpoints from namespace %v. Reason: %+v", namespace, err)
 		}
 		for _, checkpoint := range checkpointList.Items {
 
 			klog.V(3).Infof("Loading VPA %s/%s checkpoint for %s", checkpoint.ObjectMeta.Namespace, checkpoint.Spec.VPAObjectName, checkpoint.Spec.ContainerName)
 			err = feeder.setVpaCheckpoint(&checkpoint)
 			if err != nil {
-				klog.Errorf("Error while loading checkpoint. Reason: %+v", err)
+				klog.Fatalf("Error while loading checkpoint. Reason: %+v", err)
 			}
 
 		}


### PR DESCRIPTION
#### What type of PR is this?
This PR updates the VPA recommender behavior to fail fast during startup if it encounters any errors while loading checkpoint data.

Previously, the recommender would log errors when it failed to read or process checkpoint data, but continue running. This resulted in silently falling back to a state with no historical data, potentially leading to inaccurate recommendations and reduced effectiveness of autoscaling.

With this change:

- Any failure to list or load VPA checkpoints will cause the recommender to exit immediately.
- This ensures the system does not run in a degraded or misleading state without historical context.

This behavior aligns with the principle of failing early and loudly in the presence of critical data corruption or unavailability, especially given the importance of checkpoints to VPA's decision-making logic.

