### PR TITLE
Metric Client Failure Bug Fix

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
@@ -18,6 +18,7 @@ package metrics
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -128,13 +129,18 @@ func (s podMetricsSource) List(ctx context.Context, namespace string, opts v1.Li
 	close(customResChan)
 
 	podMetrics := <-resChan
-	if podMetrics == nil || s.customMetricsLister == nil {
+	// Early return if we don't have customMetricsLister
+	if s.customMetricsLister == nil {
+		// If we couldn't find it, return an error
+		if podMetrics == nil {
+			return nil, fmt.Errorf("PodMetrics not found (potentially timed out)")
+		}
 		return podMetrics, nil
 	}
 
 	customPodMetrics := <-customResChan
 	if customPodMetrics == nil {
-		return podMetrics, nil
+		return podMetrics, fmt.Errorf("CustomPodMetrics not found (potentially timed out)")
 	}
 
 	// Index the custom query results by namespace then pod name then container name then resource.

--- a/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go
@@ -18,7 +18,6 @@ package metrics
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
@@ -93,6 +92,9 @@ func (s podMetricsSource) List(ctx context.Context, namespace string, opts v1.Li
 	resChan := make(chan *v1beta1.PodMetricsList, 1)
 	customResChan := make(chan *v1beta1.PodMetricsList, 1)
 
+	var podMetricError error
+	var customMetricError error
+
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
@@ -101,6 +103,7 @@ func (s podMetricsSource) List(ctx context.Context, namespace string, opts v1.Li
 		if err != nil {
 			// TODO(leekathy): Emit metrics and setup alerting.
 			klog.ErrorS(err, "Failed to query pod usage metrics from the Metrics API")
+			podMetricError = err
 			resChan <- nil
 			return
 		}
@@ -116,6 +119,7 @@ func (s podMetricsSource) List(ctx context.Context, namespace string, opts v1.Li
 			if err != nil {
 				// TODO(leekathy): Emit metrics and setup alerting.
 				klog.ErrorS(err, "Failed to query pod custom usage metrics from M3")
+				customMetricError = err
 				resChan <- nil
 				return
 			}
@@ -133,14 +137,14 @@ func (s podMetricsSource) List(ctx context.Context, namespace string, opts v1.Li
 	if s.customMetricsLister == nil {
 		// If we couldn't find it, return an error
 		if podMetrics == nil {
-			return nil, fmt.Errorf("PodMetrics not found (potentially timed out)")
+			return nil, podMetricError
 		}
 		return podMetrics, nil
 	}
 
 	customPodMetrics := <-customResChan
 	if customPodMetrics == nil {
-		return podMetrics, fmt.Errorf("CustomPodMetrics not found (potentially timed out)")
+		return podMetrics, customMetricError
 	}
 
 	// Index the custom query results by namespace then pod name then container name then resource.


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

We introduced a bug when attempting to fast return [here](https://github.com/jodzga/autoscaler/blob/db-vpa-release-1.0/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_source.go#L130-L133).

```
...
podMetrics := <-resChan
if podMetrics == nil || s.customMetricsLister == nil {
return podMetrics, nil
}
..
```

If `customMetricsLister` is nil, then we'd like to fast return with our results. However, our logic doesn't handle the case where podMetrics might be nil. Here we should add logic to return an error if this is the case, as we are dependent on finding errors in the code that calls this [here](https://github.com/jodzga/autoscaler/blob/db-vpa-release-1.0/vertical-pod-autoscaler/pkg/recommender/input/metrics/metrics_client.go#L69-L70).