### PR TITLE
Skip logging recommendation missing when no matching pods

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/model/cluster.go
+++ b/vertical-pod-autoscaler/pkg/recommender/model/cluster.go
@@ -426,6 +426,14 @@ func (cluster *ClusterState) RecordRecommendation(vpa *Vpa, now time.Time) error
 		delete(cluster.EmptyVPAs, vpa.ID)
 		return nil
 	}
+
+	// Check if VPA has any matching pods before logging missing recommendation error
+	matchingPods := cluster.GetMatchingPods(vpa)
+	if len(matchingPods) == 0 {
+		// No matching pods, so no need to log missing recommendation error
+		return nil
+	}
+
 	lastLogged, ok := cluster.EmptyVPAs[vpa.ID]
 	if !ok {
 		cluster.EmptyVPAs[vpa.ID] = now


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
Reduce unnecessary error logging in VPA recommender. Currently an error is logged whenever a recommendation is missing for more than 30 minutes. 
When a VPA has no matching pods, this is expected (no data to fetch) and not an error. 
This PR updates recommender to skip logging an error when there are no matching pods for the workload

Example logs (that should be removed):
```
VPA testframework-internal/testframework-internal-ca9fa1fac5c47213-deployment-high-vpa is missing recommendation for more than 30m0s
VPA dump (With VPA Object)
HasMatchingPods: false
PodCount: 0
MatchingPods: []
VPA testframework-internal/testframework-internal-d0cbba0b68a88321-deployment-high-vpa is missing recommendation for more than 30m0s
VPA dump (With VPA Object)
HasMatchingPods: false
PodCount: 0
MatchingPods: []
```


#### Does this PR introduce a user-facing change?
no
