### PR TITLE
GC orphaned checkpoints before attempting to initialize VPA from them

### DIFF
--- a/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
+++ b/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go
@@ -280,6 +280,9 @@ func (feeder *clusterStateFeeder) InitFromCheckpoints() {
 	klog.V(3).Info("Initializing VPA from checkpoints")
 	feeder.LoadVPAs()
 
+	// First, clean up stale checkpoints to prevent loading errors
+	feeder.GarbageCollectCheckpoints()
+
 	namespaces := make(map[string]bool)
 	for _, v := range feeder.clusterState.Vpas {
 		namespaces[v.ID.Namespace] = true


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
VPAs with no matching workloads are considered unsupported and cleaned up after 7 days of no matches.
The checkpoints associated with them are also supposed to be cleaned up. When they are not cleaned up and VPA restarts, VPA will attempt to initialize the VPA which no longer exists from the checkpoint that was never cleaned up. This causes an error, leading to VPA crashlooping.

This PR fixes the crashloop by garbage collecting orphaned VPA checkpoints before attempting to initialize VPA objects from checkpoints.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note

```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
